### PR TITLE
[OT-111] [FEAT]: 백오피스 모니터링 페이지 UI 구현

### DIFF
--- a/src/app/(admin)/admin/monitoring/layout.tsx
+++ b/src/app/(admin)/admin/monitoring/layout.tsx
@@ -1,0 +1,21 @@
+import { AdminTitle } from "@admin-basecomponent";
+
+export default function UserLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <AdminTitle
+        title="모니터링"
+        description="실시간 콘텐츠 업로드 및 트랜스코딩 작업 현황을 파악합니다."
+      />
+
+      <div className="px-12 pb-12">{children}</div>
+
+      <AdminTitle
+        title="대시보드"
+        description="카테고리별 시청 통계 및 콘텐츠 전환율 지표를 분석합니다."
+      />
+
+      <div className="px-12 pb-12">{children}</div>
+    </>
+  );
+}

--- a/src/app/(admin)/admin/monitoring/layout.tsx
+++ b/src/app/(admin)/admin/monitoring/layout.tsx
@@ -9,13 +9,6 @@ export default function UserLayout({ children }: { children: React.ReactNode }) 
       />
 
       <div className="px-12 pb-12">{children}</div>
-
-      <AdminTitle
-        title="대시보드"
-        description="카테고리별 시청 통계 및 콘텐츠 전환율 지표를 분석합니다."
-      />
-
-      <div className="px-12 pb-12">{children}</div>
     </>
   );
 }

--- a/src/app/(admin)/admin/monitoring/page.tsx
+++ b/src/app/(admin)/admin/monitoring/page.tsx
@@ -1,6 +1,6 @@
 // /monitoring
-import { MonitoringContents } from "@/domains/admin/monitoring/components";
-import { StatisticsContents } from "@/domains/admin/monitoring/components";
+import { MonitoringContents } from "@admin-monitoring";
+import { StatisticsContents } from "@admin-monitoring";
 
 export default function MonitoringPage() {
   return (

--- a/src/app/(admin)/admin/monitoring/page.tsx
+++ b/src/app/(admin)/admin/monitoring/page.tsx
@@ -1,7 +1,13 @@
 // /monitoring
 import { AdminTitle } from "@/components/admin/common";
 import { MonitoringContents } from "@/domains/admin/monitoring/components";
+import { StatisticsContents } from "@/domains/admin/monitoring/components";
 
 export default function MonitoringPage() {
-  return <MonitoringContents />;
+  return (
+    <main className="flex flex-col">
+      <MonitoringContents />
+      <StatisticsContents />
+    </main>
+  );
 }

--- a/src/app/(admin)/admin/monitoring/page.tsx
+++ b/src/app/(admin)/admin/monitoring/page.tsx
@@ -1,5 +1,7 @@
 // /monitoring
+import { AdminTitle } from "@/components/admin/common";
+import { MonitoringContents } from "@/domains/admin/monitoring/components";
 
 export default function MonitoringPage() {
-  return <div>Monitoring Page</div>;
+  return <MonitoringContents />;
 }

--- a/src/app/(admin)/admin/monitoring/page.tsx
+++ b/src/app/(admin)/admin/monitoring/page.tsx
@@ -1,5 +1,4 @@
 // /monitoring
-import { AdminTitle } from "@/components/admin/common";
 import { MonitoringContents } from "@/domains/admin/monitoring/components";
 import { StatisticsContents } from "@/domains/admin/monitoring/components";
 

--- a/src/app/(admin)/admin/monitoring/page.tsx
+++ b/src/app/(admin)/admin/monitoring/page.tsx
@@ -1,0 +1,5 @@
+// /monitoring
+
+export default function MonitoringPage() {
+  return <div>Monitoring Page</div>;
+}

--- a/src/domains/admin/monitoring/components/CategoryCharts.tsx
+++ b/src/domains/admin/monitoring/components/CategoryCharts.tsx
@@ -1,0 +1,58 @@
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import { Bar } from "react-chartjs-2";
+import { CategoryStatistic } from "@/mocks/mockAdminCategoryStatistics";
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+interface CategoryChartsProps {
+  data: CategoryStatistic;
+}
+
+export default function CategoryCharts({ data }: CategoryChartsProps) {
+  const chartData = {
+    labels: data.labels,
+    datasets: [
+      {
+        data: data.data,
+        backgroundColor: "#ffd1d7",
+        borderRadius: 4,
+        barThickness: 50,
+      },
+    ],
+  };
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: false },
+    },
+    scales: {
+      y: {
+        beginAtZero: true,
+        max: 100,
+        grid: { color: "#eff0f5" },
+        border: {
+          display: true,
+          color: "#ffecef",
+          width: 1,
+        },
+        ticks: { color: "#ffecef" },
+      },
+      x: {
+        grid: { display: false },
+        ticks: { color: "#ffecef" },
+      },
+    },
+  };
+
+  return <Bar data={chartData} options={options} />;
+}

--- a/src/domains/admin/monitoring/components/MonitoringCategoryTabs.tsx
+++ b/src/domains/admin/monitoring/components/MonitoringCategoryTabs.tsx
@@ -17,7 +17,7 @@ export default function MonitoringCategoryTabs({
           key={category}
           onClick={() => onCategoryChange(category)}
           className={cn(
-            "px-4 py-1 rounded-md text-[14x] transition-all duration-200",
+            "px-4 py-1 rounded-md text-[14px] transition-all duration-200",
             activeCategory === category
               ? "bg-ot-primary-400 text-ot-text"
               : "bg-ot-primary-200 text-ot-text hover:bg-ot-primary-400",

--- a/src/domains/admin/monitoring/components/MonitoringCategoryTabs.tsx
+++ b/src/domains/admin/monitoring/components/MonitoringCategoryTabs.tsx
@@ -1,0 +1,31 @@
+import { cn } from "@/utils/cn";
+import { CATEGORIES, CategoryType } from "@/mocks/mockAdminCategoryStatistics";
+
+interface MonitoringCategoryTabsProps {
+  activeCategory: CategoryType;
+  onCategoryChange: (category: CategoryType) => void;
+}
+
+export default function MonitoringCategoryTabs({
+  activeCategory,
+  onCategoryChange,
+}: MonitoringCategoryTabsProps) {
+  return (
+    <div className="flex gap-3 mb-6">
+      {CATEGORIES.map((category) => (
+        <button
+          key={category}
+          onClick={() => onCategoryChange(category)}
+          className={cn(
+            "px-4 py-1 rounded-md text-[14x] transition-all duration-200",
+            activeCategory === category
+              ? "bg-ot-primary-400 text-ot-text"
+              : "bg-ot-primary-200 text-ot-text hover:bg-ot-primary-400",
+          )}
+        >
+          {category}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/domains/admin/monitoring/components/MonitoringContents.tsx
+++ b/src/domains/admin/monitoring/components/MonitoringContents.tsx
@@ -2,6 +2,12 @@ import { Input } from "@/components/common";
 import { UploadStatusBadge, UploadProgressBar } from "@admin-monitoring";
 import { mockAdminUploadStatus } from "@/mocks/mockAdminUploadStatus";
 
+const formatSize = (bytes: number) => {
+  if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)}GB`;
+  if (bytes >= 1024 ** 2) return `${(bytes / 1024 ** 2).toFixed(1)}MB`;
+  return `${(bytes / 1024).toFixed(1)}KB`;
+};
+
 export default function MonitoringContents() {
   const uploadstatusdata = mockAdminUploadStatus;
 
@@ -25,34 +31,32 @@ export default function MonitoringContents() {
 
         {/* 구분선 */}
         <div className="h-0.5 bg-ot-gray-600 w-full" />
-
-        <table className="w-full text-left border-collapse table-auto">
-          <thead>
-            <tr className="border-b border-ot-gray-600">
-              <th className="w-[35%] pl-8 py-4 font-semibold text-ot-text text-left">파일명</th>
-              <th className="w-[12%] px-3 py-4 font-semibold text-ot-text text-left">크기</th>
-              <th className="w-[12%] px-3 py-4 font-semibold text-ot-text text-left">업로더</th>
-              <th className="w-[12%] px-3 py-4 font-semibold text-ot-text text-left">상태</th>
-              <th className="w-[15%] pr-8 py-4 font-semibold text-ot-text text-left">진행률</th>
-            </tr>
-          </thead>
-        </table>
       </div>
 
-      {/* 테이블 영역 */}
+      {/* 테이블 전체 */}
       <div className="w-full">
-        {/* overflow-y-auto no-scrollbar 스크롤바 없앨 때 옵션 붙이기 */}
-        <div className="max-h-85 overflow-y-auto scrollbar-hide">
+        <div className="max-h-100 overflow-y-auto scrollbar-hide">
           <table className="w-full text-left border-collapse table-auto">
+            <thead className="sticky top-0 bg-ot-gray-700 z-10">
+              <tr className="border-b border-ot-gray-600">
+                <th className="pl-8 py-4 font-semibold text-ot-text w-[35%] text-center">파일명</th>
+                <th className="px-3 py-4 font-semibold text-ot-text w-[15%] text-center">크기</th>
+                <th className="px-3 py-4 font-semibold text-ot-text w-[15%] text-center">업로더</th>
+                <th className="px-3 py-4 font-semibold text-ot-text w-[15%] text-center">상태</th>
+                <th className="pr-8 py-4 font-semibold text-ot-text w-[20%] text-center">진행률</th>
+              </tr>
+            </thead>
+
+            {/* 리스트 목록 */}
             <tbody className="divide-y divide-ot-gray-800">
               {uploadstatusdata.map((item, index) => (
-                <tr key={index}>
-                  <td className="w-[35%] pl-8 py-4 text-ot-text truncate text-left">
-                    {item.fileName}
+                <tr key={index} className="hover:bg-ot-gray-700/50 transition-colors">
+                  <td className="pl-8 py-4 text-ot-text truncate text-center">{item.fileName}</td>
+                  <td className="px-3 py-4 text-ot-text text-center">
+                    {formatSize(item.fileSize)}
                   </td>
-                  <td className="w-[12%] px-3 py-4 text-ot-text text-left">{item.fileSize}</td>
-                  <td className="w-[12%] px-3 py-4 text-ot-text text-left">{item.uploader}</td>
-                  <td className="w-[12%] pr-4 py-4 text-left">
+                  <td className="px-3 py-4 text-ot-text text-center">{item.uploader}</td>
+                  <td className="px-3 py-4 text-center">
                     <UploadStatusBadge
                       status={item.status}
                       text={
@@ -66,12 +70,11 @@ export default function MonitoringContents() {
                       }
                     />
                   </td>
-                  <td className="w-[15%] pr-8 py-4 text-left">
+                  <td className="pr-8 py-4 text-center">
                     <UploadProgressBar progress={item.progress} />
                   </td>
                 </tr>
               ))}
-              <tr className="hover:bg-ot-gray-700 transition-colors"></tr>
             </tbody>
           </table>
         </div>

--- a/src/domains/admin/monitoring/components/MonitoringContents.tsx
+++ b/src/domains/admin/monitoring/components/MonitoringContents.tsx
@@ -23,6 +23,7 @@ export default function MonitoringContents() {
           {/* Input 입력칸 */}
           <div className="flex-1">
             <Input
+              aria-label="콘텐츠 제목 검색"
               placeholder="콘텐츠 제목을 입력하세요"
               className="bg-ot-gray-800 border-none text-ot-text focus:placeholder-transparent"
             />
@@ -49,8 +50,8 @@ export default function MonitoringContents() {
 
             {/* 리스트 목록 */}
             <tbody className="divide-y divide-ot-gray-800">
-              {uploadstatusdata.map((item, index) => (
-                <tr key={index} className="hover:bg-ot-gray-700/50 transition-colors">
+              {uploadstatusdata.map((item) => (
+                <tr key={item.id} className="hover:bg-ot-gray-700/50 transition-colors">
                   <td className="pl-8 py-4 text-ot-text truncate text-center">{item.fileName}</td>
                   <td className="px-3 py-4 text-ot-text text-center">
                     {formatSize(item.fileSize)}

--- a/src/domains/admin/monitoring/components/MonitoringContents.tsx
+++ b/src/domains/admin/monitoring/components/MonitoringContents.tsx
@@ -1,0 +1,1 @@
+export default function MonitoringContents() {}

--- a/src/domains/admin/monitoring/components/MonitoringContents.tsx
+++ b/src/domains/admin/monitoring/components/MonitoringContents.tsx
@@ -1,7 +1,6 @@
 import { Input } from "@/components/common";
+import { UploadStatusBadge, UploadProgressBar } from "@admin-monitoring";
 import { mockAdminUploadStatus } from "@/mocks/mockAdminUploadStatus";
-import UploadStatusBadge from "./UploadStatusBadge";
-import UploadProgressBar from "./UploadProgressBar";
 
 export default function MonitoringContents() {
   const uploadstatusdata = mockAdminUploadStatus;

--- a/src/domains/admin/monitoring/components/MonitoringContents.tsx
+++ b/src/domains/admin/monitoring/components/MonitoringContents.tsx
@@ -1,21 +1,81 @@
-import { AdminSearch } from "@/components/admin/common";
+import { Input } from "@/components/common";
 import { mockAdminUploadStatus } from "@/mocks/mockAdminUploadStatus";
-import { Search } from "lucide-react";
+import UploadStatusBadge from "./UploadStatusBadge";
+import UploadProgressBar from "./UploadProgressBar";
 
 export default function MonitoringContents() {
   const uploadstatusdata = mockAdminUploadStatus;
 
   return (
-    <div className="flex flex-col gap-6">
-      <div className="flex gap-4">
-        <div className="w-36 bg-ot-gray-800 p-3 border border-ot-gray-700 rounded-lg">
-          업로드 작업
+    <div className="flex flex-col rounded-xl overflow-hidden bg-ot-gray-700">
+      <div className="bg-ot-gray-700">
+        {/* 표 제목 영역 : "업로드 작업" 텍스트 + Input 입력칸 묶음 */}
+        <div className="flex items-center gap-4 pl-4 pr-2 py-2">
+          {/* "업로드 작업" 텍스트 */}
+          <span className="text-ot-text font-semibold text-[16px] whitespace-nowrap">
+            업로드 작업
+          </span>
+          {/* Input 입력칸 */}
+          <div className="flex-1">
+            <Input
+              placeholder="콘텐츠 제목을 입력하세요"
+              className="bg-ot-gray-800 border-none text-ot-text focus:placeholder-transparent"
+            />
+          </div>
         </div>
-        <input
-          type="text"
-          className="flex-1 bg-ot-gray-800 p-3 border border-ot-gray-700 rounded-lg"
-          placeholder="콘텐츠 제목을 입력하세요"
-        />
+
+        {/* 구분선 */}
+        <div className="h-0.5 bg-ot-gray-600 w-full" />
+
+        <table className="w-full text-left border-collapse table-auto">
+          <thead>
+            <tr className="border-b border-ot-gray-600">
+              <th className="w-[35%] pl-8 py-4 font-semibold text-ot-text text-left">파일명</th>
+              <th className="w-[12%] px-3 py-4 font-semibold text-ot-text text-left">크기</th>
+              <th className="w-[12%] px-3 py-4 font-semibold text-ot-text text-left">업로더</th>
+              <th className="w-[12%] px-3 py-4 font-semibold text-ot-text text-left">상태</th>
+              <th className="w-[15%] pr-8 py-4 font-semibold text-ot-text text-left">진행률</th>
+            </tr>
+          </thead>
+        </table>
+      </div>
+
+      {/* 테이블 영역 */}
+      <div className="w-full">
+        {/* overflow-y-auto no-scrollbar 스크롤바 없앨 때 옵션 붙이기 */}
+        <div className="max-h-85 overflow-y-auto scrollbar-hide">
+          <table className="w-full text-left border-collapse table-auto">
+            <tbody className="divide-y divide-ot-gray-800">
+              {uploadstatusdata.map((item, index) => (
+                <tr key={index}>
+                  <td className="w-[35%] pl-8 py-4 text-ot-text truncate text-left">
+                    {item.fileName}
+                  </td>
+                  <td className="w-[12%] px-3 py-4 text-ot-text text-left">{item.fileSize}</td>
+                  <td className="w-[12%] px-3 py-4 text-ot-text text-left">{item.uploader}</td>
+                  <td className="w-[12%] pr-4 py-4 text-left">
+                    <UploadStatusBadge
+                      status={item.status}
+                      text={
+                        item.status === "ORIGIN_UPLOADED"
+                          ? "s3 업로드 완료"
+                          : item.status === "TRANSCODING"
+                            ? "트랜스코딩"
+                            : item.status === "UPLOADING"
+                              ? "재업로드 중"
+                              : "완료"
+                      }
+                    />
+                  </td>
+                  <td className="w-[15%] pr-8 py-4 text-left">
+                    <UploadProgressBar progress={item.progress} />
+                  </td>
+                </tr>
+              ))}
+              <tr className="hover:bg-ot-gray-700 transition-colors"></tr>
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   );

--- a/src/domains/admin/monitoring/components/MonitoringContents.tsx
+++ b/src/domains/admin/monitoring/components/MonitoringContents.tsx
@@ -1,1 +1,22 @@
-export default function MonitoringContents() {}
+import { AdminSearch } from "@/components/admin/common";
+import { mockAdminUploadStatus } from "@/mocks/mockAdminUploadStatus";
+import { Search } from "lucide-react";
+
+export default function MonitoringContents() {
+  const uploadstatusdata = mockAdminUploadStatus;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex gap-4">
+        <div className="w-36 bg-ot-gray-800 p-3 border border-ot-gray-700 rounded-lg">
+          업로드 작업
+        </div>
+        <input
+          type="text"
+          className="flex-1 bg-ot-gray-800 p-3 border border-ot-gray-700 rounded-lg"
+          placeholder="콘텐츠 제목을 입력하세요"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/domains/admin/monitoring/components/MonitoringContents.tsx
+++ b/src/domains/admin/monitoring/components/MonitoringContents.tsx
@@ -37,7 +37,7 @@ export default function MonitoringContents() {
       {/* 테이블 전체 */}
       <div className="w-full">
         <div className="max-h-100 overflow-y-auto scrollbar-hide">
-          <table className="w-full text-left border-collapse table-auto">
+          <table className="w-full text-left border-collapse table-fixed">
             <thead className="sticky top-0 bg-ot-gray-700 z-10">
               <tr className="border-b border-ot-gray-600">
                 <th className="pl-8 py-4 font-semibold text-ot-text w-[35%] text-center">파일명</th>
@@ -52,7 +52,9 @@ export default function MonitoringContents() {
             <tbody className="divide-y divide-ot-gray-800">
               {uploadstatusdata.map((item) => (
                 <tr key={item.id} className="hover:bg-ot-gray-700/50 transition-colors">
-                  <td className="pl-8 py-4 text-ot-text truncate text-center">{item.fileName}</td>
+                  <td className="pl-8 py-4 text-ot-text truncate text-center max-w-0 overflow-hidden">
+                    {item.fileName}
+                  </td>
                   <td className="px-3 py-4 text-ot-text text-center">
                     {formatSize(item.fileSize)}
                   </td>

--- a/src/domains/admin/monitoring/components/StatisticsContents.tsx
+++ b/src/domains/admin/monitoring/components/StatisticsContents.tsx
@@ -1,4 +1,13 @@
+"use client";
+import { useState } from "react";
+import MonitoringCategoryTabs from "./MonitoringCategoryTabs";
+import CategoryCharts from "./CategoryCharts";
+import { mockAdminCategoryStatistics, CategoryType } from "@/mocks/mockAdminCategoryStatistics";
+
 export default function StatisticsContents() {
+  const [activeCategory, setActiveCategory] = useState<CategoryType>("영화");
+  const currentStatData = mockAdminCategoryStatistics[activeCategory];
+
   return (
     <div className="w-full flex flex-col">
       {/* 제목 & 설명글 영역 */}
@@ -15,13 +24,19 @@ export default function StatisticsContents() {
 
       <section className="grid grid-cols-12 gap-6 items-start">
         {/* [왼쪽] 카테고리별 #태그 시청 통계 그래프 모음 */}
-        <div className="col-span-8 bg-ot-gray-700 rounded-xl p-6 h-90">
-          <h3 className="text-ot-text font-bold text-[18px] mb-4">
+        <div className="col-span-8 bg-ot-gray-700 rounded-xl p-8 h-90 flex flex-col">
+          <h3 className="text-ot-text font-bold text-[18px] mb-3">
             카테고리별 #태그 시청 통계 (월별)
           </h3>
-          {/* 차트 컴포넌트가 들어갈 자리 */}
-          <div className="w-full h-62 bg-ot-gray-900 rounded-lg flex items-center justify-center">
-            <span className="text-ot-gray-600">Chart Placeholder</span>
+
+          {/* 탭 메뉴 */}
+          <MonitoringCategoryTabs
+            activeCategory={activeCategory}
+            onCategoryChange={setActiveCategory}
+          />
+          {/* 그래프 차트 영역 */}
+          <div className="flex-1 min-h-0">
+            <CategoryCharts data={currentStatData} />
           </div>
         </div>
 

--- a/src/domains/admin/monitoring/components/StatisticsContents.tsx
+++ b/src/domains/admin/monitoring/components/StatisticsContents.tsx
@@ -1,0 +1,1 @@
+export default function StatisticsContents() {}

--- a/src/domains/admin/monitoring/components/StatisticsContents.tsx
+++ b/src/domains/admin/monitoring/components/StatisticsContents.tsx
@@ -1,1 +1,44 @@
-export default function StatisticsContents() {}
+export default function StatisticsContents() {
+  return (
+    <div className="w-full flex flex-col">
+      {/* 제목 & 설명글 영역 */}
+      <section className="mt-10 mb-8">
+        <div className="flex flex-col">
+          {/* 제목 */}
+          <p className="text-ot-text text-3xl font-bold leading-tight mb-2">대시보드</p>
+          {/* 설명글 */}
+          <p className="text-ot-placeholder text-md">
+            실시간 콘텐츠 업로드 및 트랜스코딩 작업 현황을 파악합니다.
+          </p>
+        </div>
+      </section>
+
+      <section className="grid grid-cols-12 gap-6 items-start">
+        {/* [왼쪽] 카테고리별 #태그 시청 통계 그래프 모음 */}
+        <div className="col-span-8 bg-ot-gray-700 rounded-xl p-6 h-90">
+          <h3 className="text-ot-text font-bold text-[18px] mb-4">
+            카테고리별 #태그 시청 통계 (월별)
+          </h3>
+          {/* 차트 컴포넌트가 들어갈 자리 */}
+          <div className="w-full h-62 bg-ot-gray-900 rounded-lg flex items-center justify-center">
+            <span className="text-ot-gray-600">Chart Placeholder</span>
+          </div>
+        </div>
+
+        {/* [오른쪽] 숏폼 콘텐츠 전환율 값 */}
+        <div className="flex flex-col col-span-4 rounded-xl p-6 h-90 bg-ot-gray-700">
+          <h3 className="text-ot-text font-bold text-[18px]">숏폼 → 콘텐츠 전환율 (월별)</h3>
+
+          <div className="flex-1 flex items-center justify-center">
+            <div className="w-full flex flex-col items-center justify-center py-10 border border-ot-gray-600 rounded-lg bg-ot-gray-800/50">
+              <div className="flex items-center justify-center gap-3">
+                <span className="text-[48px] font-bold text-ot-primary-100">18.5%</span>
+                <span className="text-ot-primary-200 text-[18px] font-semibold">+ 2.1% ↑</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/domains/admin/monitoring/components/StatisticsContents.tsx
+++ b/src/domains/admin/monitoring/components/StatisticsContents.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useState } from "react";
-import MonitoringCategoryTabs from "./MonitoringCategoryTabs";
-import CategoryCharts from "./CategoryCharts";
+import { MonitoringCategoryTabs } from "@admin-monitoring";
+import { CategoryCharts } from "@admin-monitoring";
 import { mockAdminCategoryStatistics, CategoryType } from "@/mocks/mockAdminCategoryStatistics";
 
 export default function StatisticsContents() {

--- a/src/domains/admin/monitoring/components/UploadProgressBar.tsx
+++ b/src/domains/admin/monitoring/components/UploadProgressBar.tsx
@@ -6,12 +6,21 @@ interface UploadProgressBarProps {
 }
 
 export default function UploadProgressBar({ progress = 0, className }: UploadProgressBarProps) {
+  const safeProgress = Math.min(100, Math.max(0, progress));
+
   return (
-    <div className={cn("flex items-center w-full", className)}>
+    <div
+      className={cn("flex items-center w-full", className)}
+      role="progressbar"
+      aria-label="업로드 진행률"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={safeProgress}
+    >
       <div className="relative w-full h-2 bg-ot-gray-600 rounded-full overflow-hidden">
         <div
           className="h-full bg-ot-primary-gradient rounded-full"
-          style={{ width: `${progress}%` }}
+          style={{ width: `${safeProgress}%` }}
         />
       </div>
     </div>

--- a/src/domains/admin/monitoring/components/UploadProgressBar.tsx
+++ b/src/domains/admin/monitoring/components/UploadProgressBar.tsx
@@ -1,0 +1,19 @@
+import { cn } from "@/utils/cn";
+
+interface UploadProgressBarProps {
+  progress: number;
+  className?: string;
+}
+
+export default function UploadProgressBar({ progress = 0, className }: UploadProgressBarProps) {
+  return (
+    <div className={cn("flex items-center w-full", className)}>
+      <div className="relative w-full h-2 bg-ot-gray-600 rounded-full overflow-hidden">
+        <div
+          className="h-full bg-ot-primary-gradient rounded-full"
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/domains/admin/monitoring/components/UploadStatusBadge.tsx
+++ b/src/domains/admin/monitoring/components/UploadStatusBadge.tsx
@@ -12,10 +12,10 @@ export default function UploadStatusBadge({
   className,
 }: UploadStatusBadgeProps) {
   const statusStyles = {
-    ORIGIN_UPLOADED: "bg-ot-secondary-200 text-ot-secondary-600 ",
-    TRANSCODING: "bg-ot-primary-200 text-ot-primary-500 ",
-    UPLOADING: "bg-ot-secondary-400 text-ot-secondary-900 ",
-    COMPLETED: "bg-ot-gray-600 text-ot-gray-900 ",
+    ORIGIN_UPLOADED: "bg-[#A885F6] text-ot-secondary-800",
+    TRANSCODING: "bg-[#F59E0B] text-ot-text",
+    UPLOADING: "bg-[#6EA3F8] text-ot-secondary-900",
+    COMPLETED: "bg-ot-primary-200 text-ot-primary-700",
   };
 
   return (

--- a/src/domains/admin/monitoring/components/UploadStatusBadge.tsx
+++ b/src/domains/admin/monitoring/components/UploadStatusBadge.tsx
@@ -12,10 +12,10 @@ export default function UploadStatusBadge({
   className,
 }: UploadStatusBadgeProps) {
   const statusStyles = {
-    ORIGIN_UPLOADED: "bg-ot-secondary-200 text-ot-secondary-600 border-ot-secondary-500",
-    TRANSCODING: "bg-ot-primary-200 text-ot-primary-500 border-ot-primary-400",
-    UPLOADING: "bg-ot-secondary-400 text-ot-secondary-900 border-ot-secondary-800",
-    COMPLETED: "bg-ot-gray-600 text-ot-gray-900 border-ot-gray-100",
+    ORIGIN_UPLOADED: "bg-ot-secondary-200 text-ot-secondary-600 ",
+    TRANSCODING: "bg-ot-primary-200 text-ot-primary-500 ",
+    UPLOADING: "bg-ot-secondary-400 text-ot-secondary-900 ",
+    COMPLETED: "bg-ot-gray-600 text-ot-gray-900 ",
   };
 
   return (
@@ -23,7 +23,7 @@ export default function UploadStatusBadge({
       <span
         className={cn(
           "w-25 inline-flex justify-center items-center h-7",
-          "rounded-md text-[11px] font-bold border whitespace-nowrap transition-all",
+          "rounded-md text-[14px] font-bold whitespace-nowrap transition-all",
           statusStyles[status],
           className,
         )}

--- a/src/domains/admin/monitoring/components/UploadStatusBadge.tsx
+++ b/src/domains/admin/monitoring/components/UploadStatusBadge.tsx
@@ -1,0 +1,35 @@
+import { cn } from "@/utils/cn";
+
+interface UploadStatusBadgeProps {
+  text: string;
+  status: "ORIGIN_UPLOADED" | "TRANSCODING" | "UPLOADING" | "COMPLETED";
+  className?: string;
+}
+
+export default function UploadStatusBadge({
+  text,
+  status = "ORIGIN_UPLOADED",
+  className,
+}: UploadStatusBadgeProps) {
+  const statusStyles = {
+    ORIGIN_UPLOADED: "bg-ot-secondary-200 text-ot-secondary-600 border-ot-secondary-500",
+    TRANSCODING: "bg-ot-primary-200 text-ot-primary-500 border-ot-primary-400",
+    UPLOADING: "bg-ot-secondary-400 text-ot-secondary-900 border-ot-secondary-800",
+    COMPLETED: "bg-ot-gray-600 text-ot-gray-900 border-ot-gray-100",
+  };
+
+  return (
+    <div className="flex justify-center">
+      <span
+        className={cn(
+          "w-25 inline-flex justify-center items-center h-7",
+          "rounded-md text-[11px] font-bold border whitespace-nowrap transition-all",
+          statusStyles[status],
+          className,
+        )}
+      >
+        {text}
+      </span>
+    </div>
+  );
+}

--- a/src/domains/admin/monitoring/components/index.ts
+++ b/src/domains/admin/monitoring/components/index.ts
@@ -1,0 +1,2 @@
+export { default as MonitoringContents } from "./MonitoringContents";
+export { default as StatisticsContents } from "./StatisticsContents";

--- a/src/domains/admin/monitoring/components/index.ts
+++ b/src/domains/admin/monitoring/components/index.ts
@@ -2,3 +2,5 @@ export { default as MonitoringContents } from "./MonitoringContents";
 export { default as StatisticsContents } from "./StatisticsContents";
 export { default as UploadStatusBadge } from "./UploadStatusBadge";
 export { default as UploadProgressBar } from "./UploadProgressBar";
+export { default as MonitoringCategoryTabs } from "./MonitoringCategoryTabs";
+export { default as CategoryCharts } from "./CategoryCharts";

--- a/src/domains/admin/monitoring/components/index.ts
+++ b/src/domains/admin/monitoring/components/index.ts
@@ -1,2 +1,4 @@
 export { default as MonitoringContents } from "./MonitoringContents";
 export { default as StatisticsContents } from "./StatisticsContents";
+export { default as UploadStatusBadge } from "./UploadStatusBadge";
+export { default as UploadProgressBar } from "./UploadProgressBar";

--- a/src/domains/mypage/components/bookmark/BookmarkBox.tsx
+++ b/src/domains/mypage/components/bookmark/BookmarkBox.tsx
@@ -2,9 +2,7 @@
 
 import { useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import BookmarkFilterBar from "@/domains/mypage/components/bookmark/BookmarkFilterBar";
-import BookmarkContentList from "@/domains/mypage/components/bookmark/BookmarkContentList";
-import BookmarkShortsList from "@/domains/mypage/components/bookmark/BookmarkShortsList";
+import { BookmarkFilterBar, BookmarkContentList, BookmarkShortsList } from "@mypage-bookmark";
 
 interface BookmarkBoxProps {
   filter: "contents" | "shorts";

--- a/src/domains/mypage/components/bookmark/BookmarkShortsList.tsx
+++ b/src/domains/mypage/components/bookmark/BookmarkShortsList.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import Image from "next/image";
 import { X } from "lucide-react";
-import ConfirmModal from "@/domains/mypage/components/ConfirmModal";
+import { ConfirmModal } from "@mypage";
 import { BookmarkShortsMockData } from "@/mocks/mockbookmarkshorts";
 
 export default function BookmarkShortsList() {

--- a/src/domains/mypage/components/dashboard/DashboardContentBox.tsx
+++ b/src/domains/mypage/components/dashboard/DashboardContentBox.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { DashboardContentsMockData } from "@/mocks/mockDashboardcontent";
-import DashboardContentList from "@/domains/mypage/components/dashboard/DashboardContentList";
+import { DashboardContentList } from "@mypage-dashboard";
 
 export default function DashboardContentBox() {
   return (

--- a/src/domains/mypage/components/dashboard/DashboardContentList.tsx
+++ b/src/domains/mypage/components/dashboard/DashboardContentList.tsx
@@ -5,7 +5,7 @@ import { Pie } from "react-chartjs-2";
 import { Chart as ChartJS, ArcElement, Tooltip, Legend, ChartOptions } from "chart.js";
 import ChartDataLabels from "chartjs-plugin-datalabels";
 import { DashboardData, TagDetail } from "@/domains/mypage/types/dashboard";
-import TagStatsModal from "@/domains/mypage/components/dashboard/TagStatsModal";
+import { TagStatsModal } from "@mypage-dashboard";
 
 ChartJS.register(ArcElement, Tooltip, Legend, ChartDataLabels);
 

--- a/src/domains/mypage/components/dashboard/TagStatsModal.tsx
+++ b/src/domains/mypage/components/dashboard/TagStatsModal.tsx
@@ -4,8 +4,7 @@ import { useEffect, useState, useRef } from "react";
 import { createPortal } from "react-dom";
 import { X } from "lucide-react";
 import { RecommendedContent } from "@/domains/mypage/types/dashboard";
-import TagStatsModalList from "@/domains/mypage/components/dashboard/TagStatsModalList";
-import TagStatsModalGraph from "@/domains/mypage/components/dashboard/TagStatsModalGraph";
+import { TagStatsModalList, TagStatsModalGraph } from "@mypage-dashboard";
 import { useOutsideClick } from "@/hooks/useOutsideClick";
 
 interface TagStatsModalProps {

--- a/src/domains/mypage/components/dashboard/TagStatsModalList.tsx
+++ b/src/domains/mypage/components/dashboard/TagStatsModalList.tsx
@@ -3,8 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
 import { RecommendedContent } from "@/domains/mypage/types/dashboard";
-import LeftListScroll from "@/domains/mypage/components/LeftListScroll";
-import RightListScroll from "@/domains/mypage/components/RightListScroll";
+import { LeftListScroll, RightListScroll } from "@mypage";
 
 interface TagStatsModalListProps {
   items: RecommendedContent[];

--- a/src/domains/mypage/components/main/MyPageContent.tsx
+++ b/src/domains/mypage/components/main/MyPageContent.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import TabBar from "@/domains/mypage/components/main/TabBar";
-import RecentContentBox from "@/domains/mypage/components/recenthistory/RecentContentBox";
-import BookmarkBox from "@/domains/mypage/components/bookmark/BookmarkBox";
+import { TabBar } from "@mypage-main";
+import { RecentContentBox } from "@mypage-recenthistory";
+import { BookmarkBox } from "@mypage-bookmark";
 
 type TabType = "recenthistory" | "bookmark";
 

--- a/src/domains/mypage/components/main/MyReviewModal.tsx
+++ b/src/domains/mypage/components/main/MyReviewModal.tsx
@@ -5,7 +5,7 @@ import { createPortal } from "react-dom";
 import Image from "next/image";
 import { X } from "lucide-react";
 import { mockReviews } from "@/mocks/mockReviews";
-import ConfirmModal from "@/domains/mypage/components/ConfirmModal";
+import { ConfirmModal } from "@mypage";
 import { useOutsideClick } from "@/hooks/useOutsideClick";
 
 interface MyReviewModalProps {

--- a/src/domains/mypage/components/main/UserMenuButtons.tsx
+++ b/src/domains/mypage/components/main/UserMenuButtons.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import MyReviewModal from "@/domains/mypage/components/main/MyReviewModal";
+import { MyReviewModal } from "@mypage-main";
 import { CommonButton } from "@basecomponent";
 
 export default function UserMenuButtons() {

--- a/src/domains/mypage/components/profile/AccountActionButtons.tsx
+++ b/src/domains/mypage/components/profile/AccountActionButtons.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { CommonButton } from "@basecomponent";
-import ConfirmModal from "../ConfirmModal";
+import { ConfirmModal } from "@mypage";
 
 export default function AccountActionButtons() {
   const [isLogoutModalOpen, setIsLogoutModalOpen] = useState<boolean>(false);

--- a/src/domains/mypage/components/profile/EditFavoriteTagsUI.tsx
+++ b/src/domains/mypage/components/profile/EditFavoriteTagsUI.tsx
@@ -1,21 +1,12 @@
 "use client";
 
 import { useState } from "react";
-import ListCategory from "@/domains/onboard/components/Interest/ListCategory";
-import SelectTag from "@/domains/onboard/components/Interest/SelectTag";
-import SelectedTag from "@/domains/onboard/components/Interest/SelectedTag";
-import FinishEditButton from "@/domains/mypage/components/profile/FinishEditButton";
+import { ListCategory, SelectTag, SelectedTag } from "@onboard-interest";
+import { FinishEditButton } from "@mypage-profile";
 import { Category } from "@/types/category";
 import { TAGS } from "@/types/tags";
 
-const CATEGORIES: Category[] = [
-  "영화",
-  "드라마",
-  "예능",
-  "다큐",
-  "뉴스",
-  "스포츠",
-];
+const CATEGORIES: Category[] = ["영화", "드라마", "예능", "다큐", "뉴스", "스포츠"];
 
 const INITIAL_TAGS_BY_CATEGORY: Record<Category, string[]> = {
   영화: [],
@@ -28,9 +19,8 @@ const INITIAL_TAGS_BY_CATEGORY: Record<Category, string[]> = {
 
 export default function EditFavoriteTagsUI() {
   const [selectedCategory, setSelectedCategory] = useState<Category>("영화");
-  const [selectedTagsByCategory, setSelectedTagsByCategory] = useState<
-    Record<Category, string[]>
-  >(INITIAL_TAGS_BY_CATEGORY);
+  const [selectedTagsByCategory, setSelectedTagsByCategory] =
+    useState<Record<Category, string[]>>(INITIAL_TAGS_BY_CATEGORY);
 
   const currentTags = TAGS[selectedCategory];
   const selectedTags = selectedTagsByCategory[selectedCategory];
@@ -67,11 +57,7 @@ export default function EditFavoriteTagsUI() {
               onSelectCategory={handleSelectCategory}
             />
           </div>
-          <SelectTag
-            tags={currentTags}
-            selectedTags={selectedTags}
-            onToggleTag={handleToggleTag}
-          />
+          <SelectTag tags={currentTags} selectedTags={selectedTags} onToggleTag={handleToggleTag} />
         </div>
 
         {/* 선택된 관심사 표시 */}

--- a/src/domains/mypage/components/profile/ProfileEditor.tsx
+++ b/src/domains/mypage/components/profile/ProfileEditor.tsx
@@ -2,7 +2,7 @@
 
 import { useState, KeyboardEvent } from "react";
 import Image from "next/image";
-import { Input } from "@/components/common/Input";
+import { Input } from "@basecomponent";
 
 export default function ProfileEditor() {
   const [inputValue, setInputValue] = useState("");

--- a/src/domains/mypage/components/recenthistory/RecentContentBox.tsx
+++ b/src/domains/mypage/components/recenthistory/RecentContentBox.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import RecentContentList from "@/domains/mypage/components/recenthistory/RecentContentList";
+import { RecentContentList } from "@mypage-recenthistory";
 import { mockRecentData } from "@/mocks/mockRecent";
 
 export default function RecentContentBox() {

--- a/src/domains/mypage/components/recenthistory/RecentContentList.tsx
+++ b/src/domains/mypage/components/recenthistory/RecentContentList.tsx
@@ -2,8 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
-import RightListScroll from "@/domains/mypage/components/RightListScroll";
-import LeftListScroll from "@/domains/mypage/components/LeftListScroll";
+import { RightListScroll, LeftListScroll } from "@mypage";
 import { RecentItem } from "@/domains/mypage/types/recenthistory";
 
 interface RecentContentListProps {

--- a/src/domains/mypage/components/withdraw/WithdrawButton.tsx
+++ b/src/domains/mypage/components/withdraw/WithdrawButton.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { CommonButton } from "@basecomponent";
-import ConfirmModal from "../ConfirmModal";
+import { ConfirmModal } from "@mypage";
 
 export default function WithdrawButton() {
   const [isWithdrawModalOpen, setIsWithdrawModalOpen] = useState<boolean>(false);

--- a/src/domains/mypage/components/withdraw/WithdrawContentList.tsx
+++ b/src/domains/mypage/components/withdraw/WithdrawContentList.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import Image from "next/image";
-import { RightListScroll, LeftListScroll} from "@mypage"
+import { RightListScroll, LeftListScroll } from "@mypage";
 import { WithdrawContent } from "@/domains/mypage/types/withdrawcontent";
 
 interface WithdrawContentListProps {

--- a/src/mocks/mockAdminCategoryStatistics.ts
+++ b/src/mocks/mockAdminCategoryStatistics.ts
@@ -1,0 +1,35 @@
+export const CATEGORIES = ["영화", "드라마", "예능", "다큐", "뉴스", "스포츠"] as const;
+
+export type CategoryType = (typeof CATEGORIES)[number];
+
+export interface CategoryStatistic {
+  labels: string[];
+  data: number[];
+}
+
+export const mockAdminCategoryStatistics: Record<CategoryType, CategoryStatistic> = {
+  영화: {
+    labels: ["로맨스", "사극", "액션", "코미디", "SF", "호러", "뮤지컬"],
+    data: [52, 84, 5, 32, 38, 21, 10],
+  },
+  드라마: {
+    labels: ["로맨스", "코미디", "가족", "의학", "법정", "스릴러", "역사", "판타지"],
+    data: [70, 45, 30, 60, 25, 80, 40, 55],
+  },
+  예능: {
+    labels: ["토크쇼", "리얼리티", "여행", "서바이벌", "코미디", "연예"],
+    data: [40, 90, 65, 50, 75, 30],
+  },
+  다큐: {
+    labels: ["사회", "환경", "과학", "역사"],
+    data: [20, 15, 45, 60],
+  },
+  뉴스: {
+    labels: ["정치", "사회", "국제", "연예"],
+    data: [85, 70, 40, 30],
+  },
+  스포츠: {
+    labels: ["축구", "야구", "농구", "배구", "골프", "기타"],
+    data: [95, 80, 50, 30, 25, 15],
+  },
+};

--- a/src/mocks/mockAdminUploadStatus.ts
+++ b/src/mocks/mockAdminUploadStatus.ts
@@ -1,0 +1,73 @@
+export type UploadStatus =
+  | "ORIGIN_UPLOADED" // s3 업로드 완료
+  | "TRANSCODING" // 트랜스코딩 중
+  | "UPLOADING" // 트랜스코딩된 파일 S3 업로드 중
+  | "COMPLETED"; // 전체 완료
+
+export interface UploadTask {
+  id: number;
+  fileName: string;
+  fileSize: string;
+  uploader: string;
+  status: UploadStatus;
+  progress: number;
+}
+
+export const mockAdminUploadStatus: UploadTask[] = [
+  {
+    id: 1,
+    fileName: "파묘_Final_Main.mp4",
+    fileSize: "12.5GB",
+    uploader: "editor_kim",
+    status: "TRANSCODING",
+    progress: 45,
+  },
+  {
+    id: 2,
+    fileName: "서울의봄_고화질_export.mov",
+    fileSize: "18.2GB",
+    uploader: "admin_lee",
+    status: "COMPLETED",
+    progress: 100,
+  },
+  {
+    id: 3,
+    fileName: "범죄도시4_Trailer.mp4",
+    fileSize: "5.4GB",
+    uploader: "editor_park",
+    status: "UPLOADING",
+    progress: 82,
+  },
+  {
+    id: 4,
+    fileName: "인사이드아웃2_KR_Sub.mkv",
+    fileSize: "3.1GB",
+    uploader: "editor_kim",
+    status: "ORIGIN_UPLOADED",
+    progress: 0, // 이제 막 원본이 올라와서 트랜스코딩 대기 중인 상태
+  },
+  {
+    id: 5,
+    fileName: "데드풀과울버린_Teaser.mp4",
+    fileSize: "1.2GB",
+    uploader: "admin_lee",
+    status: "TRANSCODING",
+    progress: 15, // 트랜스코딩 시작 단계
+  },
+  {
+    id: 6,
+    fileName: "듄_파트2_Main_4K.mov",
+    fileSize: "25.7GB",
+    uploader: "editor_park",
+    status: "UPLOADING",
+    progress: 30, // 트랜스코딩 후 S3 재업로드 초반 단계
+  },
+  {
+    id: 7,
+    fileName: "에이리언_로물루스_Clip.mp4",
+    fileSize: "850MB",
+    uploader: "editor_kim",
+    status: "COMPLETED",
+    progress: 100,
+  },
+];

--- a/src/mocks/mockAdminUploadStatus.ts
+++ b/src/mocks/mockAdminUploadStatus.ts
@@ -7,7 +7,7 @@ export type UploadStatus =
 export interface UploadTask {
   id: number;
   fileName: string;
-  fileSize: string;
+  fileSize: number;
   uploader: string;
   status: UploadStatus;
   progress: number;
@@ -17,7 +17,7 @@ export const mockAdminUploadStatus: UploadTask[] = [
   {
     id: 1,
     fileName: "파묘_Final_Main.mp4",
-    fileSize: "12.5GB",
+    fileSize: 12_500_000_000,
     uploader: "editor_kim",
     status: "TRANSCODING",
     progress: 45,
@@ -25,7 +25,7 @@ export const mockAdminUploadStatus: UploadTask[] = [
   {
     id: 2,
     fileName: "서울의봄_고화질_export.mov",
-    fileSize: "18.2GB",
+    fileSize: 18_200_000_000,
     uploader: "admin_lee",
     status: "COMPLETED",
     progress: 100,
@@ -33,7 +33,7 @@ export const mockAdminUploadStatus: UploadTask[] = [
   {
     id: 3,
     fileName: "범죄도시4_Trailer.mp4",
-    fileSize: "5.4GB",
+    fileSize: 5_400_000_000,
     uploader: "editor_park",
     status: "UPLOADING",
     progress: 82,
@@ -41,31 +41,31 @@ export const mockAdminUploadStatus: UploadTask[] = [
   {
     id: 4,
     fileName: "인사이드아웃2_KR_Sub.mkv",
-    fileSize: "3.1GB",
+    fileSize: 3_100_000_000,
     uploader: "editor_kim",
     status: "ORIGIN_UPLOADED",
-    progress: 0, // 이제 막 원본이 올라와서 트랜스코딩 대기 중인 상태
+    progress: 0,
   },
   {
     id: 5,
     fileName: "데드풀과울버린_Teaser.mp4",
-    fileSize: "1.2GB",
+    fileSize: 1_200_000_000,
     uploader: "admin_lee",
     status: "TRANSCODING",
-    progress: 15, // 트랜스코딩 시작 단계
+    progress: 15,
   },
   {
     id: 6,
     fileName: "듄_파트2_Main_4K.mov",
-    fileSize: "25.7GB",
+    fileSize: 25_700_000_000,
     uploader: "editor_park",
     status: "UPLOADING",
-    progress: 30, // 트랜스코딩 후 S3 재업로드 초반 단계
+    progress: 30,
   },
   {
     id: 7,
     fileName: "에이리언_로물루스_Clip.mp4",
-    fileSize: "850MB",
+    fileSize: 850_000_000,
     uploader: "editor_kim",
     status: "COMPLETED",
     progress: 100,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,7 +36,8 @@
       "@video-contents": ["./src/domains/video-contents/components"],
       "@admin-basecomponent": ["./src/components/admin/common"],
       "@admin-upload": ["./src/components/admin/common/upload"],
-      "@adminuser": ["./src/domains/admin/user/components"]
+      "@adminuser": ["./src/domains/admin/user/components"],
+      "@admin-monitoring": ["./src/domains/admin/monitoring/components"]
     }
   },
   "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,14 +23,20 @@
       "@basecomponent": ["./src/components/common"],
       "@home": ["./src/domains/home/components"],
       "@mypage": ["./src/domains/mypage/components"],
+      "@mypage-bookmark": ["./src/domains/mypage/components/bookmark"],
+      "@mypage-dashboard": ["./src/domains/mypage/components/dashboard"],
+      "@mypage-profile": ["./src/domains/mypage/components/profile"],
+      "@mypage-recenthistory": ["./src/domains/mypage/components/recenthistory"],
+      "@mypage-withdraw": ["./src/domains/mypage/components/withdraw"],
+      "@mypage-main": ["./src/domains/mypage/components/main"],
       "@onboard": ["./src/domains/onboard/components"],
+      "@onboard-interest": ["./src/domains/onboard/components/Interest"],
       "@video": ["./src/domains/player/video/components"],
       "@shorts": ["./src/domains/player/shorts/components"],
       "@video-contents": ["./src/domains/video-contents/components"],
       "@admin-basecomponent": ["./src/components/admin/common"],
       "@admin-upload": ["./src/components/admin/common/upload"],
       "@adminuser": ["./src/domains/admin/user/components"]
-
     }
   },
   "include": [


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 적어주세요
- [x] 백오피스 모니터링 페이지 UI 구현

### 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. src에 이미지 url만 등록하면 됩니다. -->

| 구현 내용 |             SE              |           13 mini           |           15 pro            |
| :-------: | :-------------------------: | :-------------------------: | :-------------------------: |
|    GIF    | <img src = "https://github.com/user-attachments/assets/0a2c3965-3a68-4720-a2ec-1d53a40b1984" width ="250"> | | |
|    GIF    | <img src = "https://github.com/user-attachments/assets/b0c8da2f-b9ce-4651-bcf9-dc155fa60a41" width ="250"> | | |


## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->
<img width="1083" height="636" alt="image" src="https://github.com/user-attachments/assets/7a73748f-3984-4828-89d9-08b1dc8d3dd9" />


## ☑️ 체크 리스트

> 체크 리스트를 확인해주세요

- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?

## #️⃣ 연관된 이슈

> ex) #46 

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 상태 배지 색 조합, 대시보드 그래프 색 조합 괜찮은지 확인 부탁드립니다.
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자 모니터링 대시보드 추가: 관리 레이아웃·페이지, 업로드 상태 테이블, 진행률 바, 상태 배지, 카테고리 탭 및 카테고리별 차트 UI 추가
  * 대시보드용 샘플 통계 및 업로드 모의 데이터 포함

* **Chores**
  * 마이페이지 관련 컴포넌트들의 임포트 경로 정리 및 경로 별칭 추가(모듈 재간소화)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->