### PR TITLE
[OT-115] [FEAT]: 백오피스 - 숏폼관리 리스트, 상세 정보, 업로드 UI 구현

### DIFF
--- a/src/app/(admin)/admin/contents/layout.tsx
+++ b/src/app/(admin)/admin/contents/layout.tsx
@@ -10,7 +10,7 @@ export default function ContentsLayout({
     <>
       <AdminTitle
         title="콘텐츠 관리"
-        description="숏폼 및 콘텐츠를 관리합니다"
+        description="콘텐츠를 관리합니다"
         action={<UploadButton />}
       />
 

--- a/src/app/(admin)/admin/shorts/layout.tsx
+++ b/src/app/(admin)/admin/shorts/layout.tsx
@@ -1,5 +1,5 @@
 import { AdminTitle } from "@admin-basecomponent";
-import { AdminShortsUploadButton } from "@/domains/admin/shorts/components/AdminShortsUploadButton";
+import { AdminShortsUploadButton } from "@admin-shorts";
 
 export default function ShortsLayout({
   children,

--- a/src/app/(admin)/admin/shorts/layout.tsx
+++ b/src/app/(admin)/admin/shorts/layout.tsx
@@ -1,0 +1,20 @@
+import { AdminTitle } from "@admin-basecomponent";
+import { AdminShortsUploadButton } from "@/domains/admin/shorts/components/AdminShortsUploadButton";
+
+export default function ShortsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <AdminTitle
+        title="숏폼 관리"
+        description="숏폼을 관리합니다"
+        action={<AdminShortsUploadButton />}
+      />
+
+      <div className="px-12 pb-12">{children}</div>
+    </>
+  );
+}

--- a/src/app/(admin)/admin/shorts/page.tsx
+++ b/src/app/(admin)/admin/shorts/page.tsx
@@ -1,0 +1,11 @@
+import AdminShrotsSection from "@/domains/admin/shorts/components/AdminShortsSection";
+import { Suspense } from "react";
+
+export default function AdminShortsPage() {
+  return (
+    <Suspense fallback={null}>
+      {/*Pre-rendering 지금은 아무것도 없음*/}
+      <AdminShrotsSection />
+    </Suspense>
+  );
+}

--- a/src/app/(admin)/admin/shorts/page.tsx
+++ b/src/app/(admin)/admin/shorts/page.tsx
@@ -1,11 +1,11 @@
-import AdminShrotsSection from "@/domains/admin/shorts/components/AdminShortsSection";
+import { AdminShortsSection } from "@admin-shorts";
 import { Suspense } from "react";
 
 export default function AdminShortsPage() {
   return (
     <Suspense fallback={null}>
       {/*Pre-rendering 지금은 아무것도 없음*/}
-      <AdminShrotsSection />
+      <AdminShortsSection />
     </Suspense>
   );
 }

--- a/src/components/admin/common/AdminSearch.tsx
+++ b/src/components/admin/common/AdminSearch.tsx
@@ -46,7 +46,7 @@ export default function AdminSearch({
         <div ref={dropdownRef} className="relative w-36">
           <button
             onClick={() => setIsOpen((prev) => !prev)}
-            className="w-full flex items-center justify-between bg-ot-gray-800 px-3 py-3 border border-ot-gray-700 rounded-lg text-ot-text"
+            className="w-full flex items-center justify-between bg-ot-gray-800 px-3 py-3 border border-ot-gray-700 rounded-lg text-ot-text cursor-pointer"
           >
             <span className="text-sm">{selected}</span>
             <ChevronDown
@@ -65,7 +65,7 @@ export default function AdminSearch({
                   <button
                     onClick={() => handleSelect(option)}
                     className={cn(
-                      "w-full text-left px-3 py-2 text-sm text-ot-text hover:bg-ot-gray-700 transition-colors",
+                      "w-full text-left px-3 py-2 text-sm text-ot-text hover:bg-ot-gray-700 transition-colors cursor-pointer",
                       selected === option &&
                         "bg-ot-primary-gradient text-ot-text",
                     )}

--- a/src/components/admin/common/upload/AdminPosterUpload.tsx
+++ b/src/components/admin/common/upload/AdminPosterUpload.tsx
@@ -12,11 +12,13 @@ export interface PosterState {
 export interface AdminPosterUploadProps {
   value: PosterState;
   onChange: (value: PosterState) => void;
+  isShorts?: boolean;
 }
 
 export default function AdminPosterUpload({
   value,
   onChange,
+  isShorts = false,
 }: AdminPosterUploadProps) {
   const verticalInputRef = useRef<HTMLInputElement>(null);
   const horizontalInputRef = useRef<HTMLInputElement>(null);
@@ -89,43 +91,45 @@ export default function AdminPosterUpload({
         </div>
 
         {/* 가로 포스터 (4:3) */}
-        <div>
-          <p className="text-sm mb-2 text-ot-gray-700">가로 포스터 (4:3)</p>
-          <input
-            ref={horizontalInputRef}
-            type="file"
-            accept="image/*"
-            className="hidden"
-            onChange={handleHorizontal}
-          />
-          <div
-            className="h-85 relative border border-dashed border-ot-gray-600 rounded-lg overflow-hidden cursor-pointer hover:bg-ot-gray-200 transition-colors aspect-4/3"
-            onClick={() => horizontalInputRef.current?.click()}
-          >
-            {value.horizontal ? (
-              <>
-                <Image
-                  src={value.horizontal}
-                  fill
-                  alt="가로 포스터 미리보기"
-                  className="object-cover"
-                />
-                <button
-                  type="button"
-                  onClick={removeHorizontal}
-                  className="absolute top-2 right-2 z-10 bg-black/50 hover:bg-black/70 transition-colors rounded-full p-1 text-ot-text cursor-pointer"
-                >
-                  <X size={14} />
-                </button>
-              </>
-            ) : (
-              <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-ot-gray-600">
-                <ImageIcon size={28} strokeWidth={1} />
-                <span className="text-xs">클릭하여 업로드</span>
-              </div>
-            )}
+        {!isShorts && (
+          <div>
+            <p className="text-sm mb-2 text-ot-gray-700">가로 포스터 (4:3)</p>
+            <input
+              ref={horizontalInputRef}
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={handleHorizontal}
+            />
+            <div
+              className="h-85 relative border border-dashed border-ot-gray-600 rounded-lg overflow-hidden cursor-pointer hover:bg-ot-gray-200 transition-colors aspect-4/3"
+              onClick={() => horizontalInputRef.current?.click()}
+            >
+              {value.horizontal ? (
+                <>
+                  <Image
+                    src={value.horizontal}
+                    fill
+                    alt="가로 포스터 미리보기"
+                    className="object-cover"
+                  />
+                  <button
+                    type="button"
+                    onClick={removeHorizontal}
+                    className="absolute top-2 right-2 z-10 bg-black/50 hover:bg-black/70 transition-colors rounded-full p-1 text-ot-text cursor-pointer"
+                  >
+                    <X size={14} />
+                  </button>
+                </>
+              ) : (
+                <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-ot-gray-600">
+                  <ImageIcon size={28} strokeWidth={1} />
+                  <span className="text-xs">클릭하여 업로드</span>
+                </div>
+              )}
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/src/domains/admin/contents/components/AdminContentsSection.tsx
+++ b/src/domains/admin/contents/components/AdminContentsSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AdminSearch } from "@admin-basecomponent";
-import AdminContentsList from "./AdminContentsList"; // index 에서 변경 예정
+import { AdminContentsList } from "@admin-contents"; // index 에서 변경 예정
 import { useState } from "react";
 import { PublicType } from "@/types/admin/adminPublic";
 

--- a/src/domains/admin/contents/components/UploadButton.tsx
+++ b/src/domains/admin/contents/components/UploadButton.tsx
@@ -7,7 +7,10 @@ import AdminUploadModal from "@/domains/admin/contents/components/AdminContentsU
 
 interface UploadButtonProps {
   label?: string;
-  renderModal?: (props: { open: boolean; onClose: () => void }) => React.ReactNode;
+  renderModal?: (props: {
+    open: boolean;
+    onClose: () => void;
+  }) => React.ReactNode;
 }
 
 export default function UploadButton({
@@ -26,10 +29,11 @@ export default function UploadButton({
         {label}
       </CommonButton>
 
-      {renderModal
-        ? renderModal({ open, onClose: () => setOpen(false) })
-        : <AdminUploadModal open={open} onClose={() => setOpen(false)} />
-      }
+      {renderModal ? (
+        renderModal({ open, onClose: () => setOpen(false) })
+      ) : (
+        <AdminUploadModal open={open} onClose={() => setOpen(false)} />
+      )}
     </>
   );
 }

--- a/src/domains/admin/contents/components/index.ts
+++ b/src/domains/admin/contents/components/index.ts
@@ -1,3 +1,4 @@
 export { default as AdminContentsUploadModal } from "./AdminContentsUploadModal";
 export { default as AdminContentsDetailModal } from "./AdminContentsDetailModal";
 export { default as UploadButton } from "./UploadButton";
+export { default as AdminContentsList } from "./AdminContentsList";

--- a/src/domains/admin/shorts/components/AdminOriginalContentsDropdown.tsx
+++ b/src/domains/admin/shorts/components/AdminOriginalContentsDropdown.tsx
@@ -65,7 +65,7 @@ export default function AdminOriginalContentsDropdown({
                     setSearch(searchInputRef.current?.value ?? "");
                   }
                 }}
-                placeholder="시리즈 검색"
+                placeholder="원본 콘텐츠 검색"
                 className="flex-1 text-sm placeholder:text-ot-gray-600 outline-none text-ot-background"
               />
               <Search size={15} className="text-ot-gray-600 shrink-0" />

--- a/src/domains/admin/shorts/components/AdminOriginalContentsDropdown.tsx
+++ b/src/domains/admin/shorts/components/AdminOriginalContentsDropdown.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useOutsideClick } from "@/hooks/useOutsideClick";
+import { ChevronDown, Search } from "lucide-react";
+import { useState, useRef } from "react";
+
+export interface AdminOriginalContentsDropdownProps {
+  originalList: string[];
+  value: string | null;
+  onChange: (original: string | null) => void;
+}
+
+export default function AdminOriginalContentsDropdown({
+  value,
+  onChange,
+  originalList,
+}: AdminOriginalContentsDropdownProps) {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [search, setSearch] = useState<string>("");
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  const filtered = originalList.filter((s) => s.includes(search));
+
+  useOutsideClick(dropdownRef, () => setIsOpen(false), isOpen);
+
+  const handleSelect = (original: string) => {
+    onChange(original);
+    setIsOpen(false);
+    setSearch("");
+    if (searchInputRef.current) searchInputRef.current.value = "";
+  };
+
+  return (
+    <div>
+      <p className="font-semibold text-lg mb-2">원본 콘텐츠 선택</p>
+      <div ref={dropdownRef} className="relative">
+        <button
+          type="button"
+          onClick={() => {
+            setIsOpen((prev) => !prev);
+            setSearch("");
+          }}
+          className="w-full flex items-center justify-between border border-ot-gray-600 rounded-lg py-3 px-4 text-sm text-left bg-ot-text hover:bg-ot-gray-200 transition-colors cursor-pointer"
+        >
+          <span className={value ? "text-ot-background" : "text-ot-gray-600"}>
+            {value ?? "원본 콘텐츠 선택"}
+          </span>
+          <ChevronDown
+            size={16}
+            className={`text-ot-gray-600 shrink-0 transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`}
+          />
+        </button>
+
+        {isOpen && (
+          <div className="absolute top-full left-0 right-0 z-20 mt-1 bg-ot-text rounded-lg shadow-lg">
+            <div className="flex items-center gap-2 px-3 py-2 border border-ot-gray-600 rounded-lg m-1">
+              <input
+                type="text"
+                autoFocus
+                ref={searchInputRef}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    setSearch(searchInputRef.current?.value ?? "");
+                  }
+                }}
+                placeholder="시리즈 검색"
+                className="flex-1 text-sm placeholder:text-ot-gray-600 outline-none text-ot-background"
+              />
+              <Search size={15} className="text-ot-gray-600 shrink-0" />
+            </div>
+            <div className="max-h-48 overflow-y-auto">
+              {filtered.length > 0 ? (
+                filtered.map((original) => (
+                  <button
+                    type="button"
+                    key={original}
+                    onClick={() => handleSelect(original)}
+                    className={`w-full text-left px-4 py-3 text-sm transition-colors cursor-pointer ${
+                      value === original
+                        ? "bg-ot-primary-gradient text-ot-text"
+                        : "text-ot-background hover:bg-ot-gray-200"
+                    }`}
+                  >
+                    {original}
+                  </button>
+                ))
+              ) : (
+                <p className="px-4 py-3 text-sm text-ot-gray-600">
+                  검색 결과가 없습니다
+                </p>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/domains/admin/shorts/components/AdminShortsDetailModal.tsx
+++ b/src/domains/admin/shorts/components/AdminShortsDetailModal.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { AdminBadge } from "@admin-basecomponent";
+import { Bookmark, X } from "lucide-react";
+import Image from "next/image";
+
+import { cn } from "@/utils/cn";
+import {
+  badgeBase,
+  CATEGORY_STYLE_MAP,
+  TAG_STYLE_MAP,
+} from "@/domains/admin/series/constants/seriesStyles";
+import { ShortsType } from "@/mocks/mockAdminShorts";
+
+interface AdminShortsDetailModalProps {
+  shorts: ShortsType | null;
+  onClose: () => void;
+}
+
+export default function AdminShortsDetailModal({
+  shorts,
+  onClose,
+}: AdminShortsDetailModalProps) {
+  if (!shorts) return null;
+
+  const formatSize = (bytes: number) => {
+    if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)}GB`;
+    if (bytes >= 1024 ** 2) return `${(bytes / 1024 ** 2).toFixed(1)}MB`;
+    return `${(bytes / 1024).toFixed(1)}KB`;
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={onClose}
+    >
+      <div
+        className="relative bg-ot-text rounded-lg w-full max-w-2xl mx-4 p-8 flex flex-col gap-6 max-h-[90vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="relative mb-8 text-ot-background">
+          <p className="text-2xl font-bold">숏폼 상세정보</p>
+          <button
+            onClick={onClose}
+            className="absolute top-0 right-0 text-ot-background hover:text-ot-gray-600 transition-colors cursor-pointer"
+          >
+            <X size={22} />
+          </button>
+        </div>
+
+        {/* 썸네일 */}
+        {/* 메인 그리드: 썸네일 좌 / 메타 우 */}
+        <section className="grid grid-cols-2 gap-x-10 text-ot-background">
+          {/* 좌측: 썸네일 */}
+          <div className="flex flex-col gap-2">
+            <p className="text-base font-semibold">썸네일 (5:7)</p>
+            <div className="relative max-w-60 aspect-5/7 rounded-lg overflow-hidden">
+              <Image
+                src={shorts.thumbnailShorts || ""}
+                alt={`${shorts.title} 세로 썸네일`}
+                fill
+                className="object-cover"
+              />
+            </div>
+          </div>
+
+          {/* 우측: 메타 정보 */}
+          <div className="flex flex-col gap-6">
+            <div>
+              <p className="text-base font-semibold">제목</p>
+              <p className="text-sm">{shorts.title}</p>
+            </div>
+
+            <div>
+              <p className="text-base font-semibold">설명</p>
+              <p className="text-sm leading-relaxed">{shorts.description}</p>
+            </div>
+
+            <div>
+              <p className="text-base font-semibold">원본 콘텐츠</p>
+              <p className="text-sm">{shorts.originalContents.originalTitle}</p>
+            </div>
+
+            <div>
+              <p className="text-base font-semibold">업로더</p>
+              <p className="text-sm">{shorts.uploader}</p>
+            </div>
+
+            {/* 재생 시간 | 파일 크기 */}
+            <div className="grid grid-cols-2">
+              <div>
+                <p className="text-base font-semibold">재생 시간</p>
+                <p className="text-sm">{shorts.duration}</p>
+              </div>
+              <div>
+                <p className="text-base font-semibold">파일 크기</p>
+                <p className="text-sm">{formatSize(shorts.size)}</p>
+              </div>
+            </div>
+
+            {/* 카테고리 | 태그 */}
+            <div className="grid grid-cols-2">
+              <div className="flex flex-col gap-1">
+                <p className="text-base font-semibold">카테고리</p>
+                <div className="flex items-center">
+                  <span
+                    className={cn(
+                      badgeBase,
+                      CATEGORY_STYLE_MAP[shorts.originalContents.category],
+                    )}
+                  >
+                    {shorts.originalContents.category}
+                  </span>
+                </div>
+              </div>
+              <div className="flex flex-col gap-1">
+                <p className="text-base font-semibold">태그</p>
+                <div className="flex items-center gap-2 flex-wrap">
+                  {shorts.originalContents.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className={cn(
+                        badgeBase,
+                        TAG_STYLE_MAP[tag] ?? "bg-ot-gray-600 text-ot-text",
+                      )}
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            {/* 공개 여부 */}
+            <div>
+              <p className="text-base font-semibold">공개 여부</p>
+              <AdminBadge variant={shorts.isPublic ? "공개" : "비공개"} />
+            </div>
+
+            {/* 북마크 | 업로드 일자 */}
+            <div className="grid grid-cols-2">
+              <div>
+                <p className="text-base font-semibold">북마크</p>
+                <p className="text-sm flex items-center gap-1">
+                  <Bookmark size={14} />
+                  {shorts.bookmarkCount.toLocaleString()}
+                </p>
+              </div>
+              <div>
+                <p className="text-base font-semibold">업로드 일자</p>
+                <p className="text-sm">{shorts.uploadDate}</p>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/domains/admin/shorts/components/AdminShortsDetailModal.tsx
+++ b/src/domains/admin/shorts/components/AdminShortsDetailModal.tsx
@@ -55,12 +55,19 @@ export default function AdminShortsDetailModal({
           <div className="flex flex-col gap-2">
             <p className="text-base font-semibold">썸네일 (5:7)</p>
             <div className="relative max-w-60 aspect-5/7 rounded-lg overflow-hidden">
-              <Image
-                src={shorts.thumbnailShorts || ""}
-                alt={`${shorts.title} 세로 썸네일`}
-                fill
-                className="object-cover"
-              />
+              {shorts.thumbnailShorts ? (
+                <Image
+                  src={shorts.thumbnailShorts}
+                  alt={`${shorts.title} 세로 썸네일`}
+                  fill
+                  className="object-cover"
+                />
+              ) : (
+                <div
+                  className="w-full h-full bg-ot-gray-200"
+                  aria-label="썸네일 없음"
+                />
+              )}
             </div>
           </div>
 

--- a/src/domains/admin/shorts/components/AdminShortsList.tsx
+++ b/src/domains/admin/shorts/components/AdminShortsList.tsx
@@ -6,7 +6,7 @@ import { Edit } from "lucide-react";
 import Image from "next/image";
 
 import { useRouter, useSearchParams } from "next/navigation";
-// import { AdminshortsDetailModal } from "@admin-shorts";
+// import { AdminShortsDetailModal } from "@/domains/admin/shorts/components/";
 
 interface AdminShortsListProps {
   filterPublic?: PublicType | null;
@@ -116,7 +116,7 @@ export default function AdminShortsList({
           </tbody>
         </table>
       </div>
-      {/* <AdminshortsDetailModal shorts={selectedshorts} onClose={handleClose} /> */}
+      {/* <AdminShortsDetailModal shorts={selectedshorts} onClose={handleClose} /> */}
     </>
   );
 }

--- a/src/domains/admin/shorts/components/AdminShortsList.tsx
+++ b/src/domains/admin/shorts/components/AdminShortsList.tsx
@@ -1,0 +1,122 @@
+"use client";
+import { mockAdminShorts } from "@/mocks/mockAdminShorts";
+import { PublicType } from "@/types/admin";
+import { AdminBadge } from "@admin-basecomponent";
+import { Edit } from "lucide-react";
+import Image from "next/image";
+
+import { useRouter, useSearchParams } from "next/navigation";
+// import { AdminshortsDetailModal } from "@admin-shorts";
+
+interface AdminShortsListProps {
+  filterPublic?: PublicType | null;
+}
+
+export default function AdminShortsList({
+  filterPublic,
+}: AdminShortsListProps) {
+  const data = filterPublic
+    ? mockAdminShorts.filter((short) =>
+        filterPublic === "공개" ? short.isPublic : !short.isPublic,
+      )
+    : mockAdminShorts;
+
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const selectedId = searchParams.get("id");
+  const selectedshorts = selectedId
+    ? (data.find((s) => s.id === Number(selectedId)) ?? null)
+    : null;
+
+  const handleRowClick = (id: number) => {
+    router.push(`?id=${id}`, { scroll: false });
+  };
+
+  const handleClose = () => {
+    router.push("?", { scroll: false });
+  };
+
+  return (
+    <>
+      <div className="mt-4 rounded-lg overflow-hidden">
+        <table className="w-full text-ot-text">
+          <colgroup>
+            <col className="w-1/9" />
+            <col className="w-5/9" />
+            <col className="w-1/9" />
+            <col className="w-1/9" />
+            <col className="w-1/9" />
+          </colgroup>
+
+          <thead className="bg-ot-gray-800 text-md font-bold">
+            <tr>
+              <th className="py-3">썸네일</th>
+              <th>제목</th>
+              <th>공개 여부</th>
+              <th>업로드일</th>
+              <th>수정</th>
+            </tr>
+          </thead>
+
+          <tbody className="bg-ot-gray-700 divide-y divide-ot-gray-800">
+            {data.map((short) => (
+              <tr
+                key={short.id}
+                onClick={() => handleRowClick(short.id)}
+                className="hover:bg-ot-gray-800/30 transition-colors"
+              >
+                <td className="py-3">
+                  <div className="relative aspect-5/7 max-w-12 w-full mx-auto">
+                    {short.thumbnailShorts ? (
+                      <Image
+                        src={short.thumbnailShorts}
+                        alt={short.title}
+                        fill
+                        className="object-cover rounded-md"
+                      />
+                    ) : (
+                      <div
+                        className="w-full h-full rounded-md bg-ot-gray-800"
+                        aria-label="썸네일 없음"
+                      />
+                    )}
+                  </div>
+                </td>
+                <td className="py-3">
+                  <div className="flex flex-col font-semibold">
+                    <span>{short.title}</span>
+                    <span className="text-sm text-ot-placeholder mt-1">
+                      {short.duration}
+                    </span>
+                  </div>
+                </td>
+
+                <td className="py-3 text-center">
+                  <AdminBadge
+                    variant={short.isPublic ? "공개" : "비공개"}
+                    className={
+                      short.isPublic
+                        ? "bg-[#CCFBF1] text-[#298880]"
+                        : "bg-ot-primary-100 text-[#882929]"
+                    }
+                  />
+                </td>
+                <td className="py-3 text-center font-semibold text-sm">
+                  {short.uploadDate}
+                </td>
+
+                <td className="py-3 text-center ">
+                  <button onClick={(e) => e.stopPropagation()}>
+                    <Edit size={20} className="hover:stroke-ot-gray-600" />
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {/* <AdminshortsDetailModal shorts={selectedshorts} onClose={handleClose} /> */}
+    </>
+  );
+}

--- a/src/domains/admin/shorts/components/AdminShortsList.tsx
+++ b/src/domains/admin/shorts/components/AdminShortsList.tsx
@@ -6,7 +6,7 @@ import { Edit } from "lucide-react";
 import Image from "next/image";
 
 import { useRouter, useSearchParams } from "next/navigation";
-// import { AdminShortsDetailModal } from "@/domains/admin/shorts/components/";
+import { AdminShortsDetailModal } from "@admin-shorts";
 
 interface AdminShortsListProps {
   filterPublic?: PublicType | null;
@@ -116,7 +116,7 @@ export default function AdminShortsList({
           </tbody>
         </table>
       </div>
-      {/* <AdminShortsDetailModal shorts={selectedshorts} onClose={handleClose} /> */}
+      <AdminShortsDetailModal shorts={selectedshorts} onClose={handleClose} />
     </>
   );
 }

--- a/src/domains/admin/shorts/components/AdminShortsSection.tsx
+++ b/src/domains/admin/shorts/components/AdminShortsSection.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { AdminSearch } from "@admin-basecomponent";
+import { useState } from "react";
+import { PublicType } from "@/types/admin/adminPublic";
+import AdminShortsList from "./AdminShortsList";
+
+const PUBLIC_FILTER_OPTIONS = ["전체", "공개", "비공개"] as const;
+
+export default function AdminShrotsSection() {
+  const [filterPublic, setFilterPublic] = useState<PublicType | null>(null);
+
+  const handleSelect = (option: string) => {
+    setFilterPublic(option === "전체" ? null : (option as PublicType));
+  };
+
+  return (
+    <>
+      <AdminSearch
+        placeholder="숏폼 제목을 입력하세요."
+        options={[...PUBLIC_FILTER_OPTIONS]}
+        onSelect={handleSelect}
+      />
+
+      <AdminShortsList filterPublic={filterPublic} />
+    </>
+  );
+}

--- a/src/domains/admin/shorts/components/AdminShortsSection.tsx
+++ b/src/domains/admin/shorts/components/AdminShortsSection.tsx
@@ -3,7 +3,7 @@
 import { AdminSearch } from "@admin-basecomponent";
 import { useState } from "react";
 import { PublicType } from "@/types/admin/adminPublic";
-import AdminShortsList from "./AdminShortsList";
+import { AdminShortsList } from "@admin-shorts";
 
 const PUBLIC_FILTER_OPTIONS = ["전체", "공개", "비공개"] as const;
 

--- a/src/domains/admin/shorts/components/AdminShortsUploadButton.tsx
+++ b/src/domains/admin/shorts/components/AdminShortsUploadButton.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { UploadButton } from "@admin-contents";
+import AdminShortsUploadModal from "./AdminShortsUploadModal";
+
+export function AdminShortsUploadButton() {
+  return (
+    <UploadButton
+      label="숏폼 업로드"
+      renderModal={({ open, onClose }) => (
+        <AdminShortsUploadModal open={open} onClose={onClose} />
+      )}
+    />
+  );
+}

--- a/src/domains/admin/shorts/components/AdminShortsUploadButton.tsx
+++ b/src/domains/admin/shorts/components/AdminShortsUploadButton.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { UploadButton } from "@admin-contents";
-import AdminShortsUploadModal from "./AdminShortsUploadModal";
+import { AdminShortsUploadModal } from "@admin-shorts";
 
-export function AdminShortsUploadButton() {
+export default function AdminShortsUploadButton() {
   return (
     <UploadButton
       label="숏폼 업로드"

--- a/src/domains/admin/shorts/components/AdminShortsUploadModal.tsx
+++ b/src/domains/admin/shorts/components/AdminShortsUploadModal.tsx
@@ -12,7 +12,7 @@ import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { CommonButton } from "@/components/common";
 import { X } from "lucide-react";
-import AdminOriginalContentsDropdown from "./AdminOriginalContentsDropdown";
+import { AdminOriginalContentsDropdown } from "@admin-shorts";
 
 interface AdminShortsUploadModalProps {
   open: boolean;

--- a/src/domains/admin/shorts/components/AdminShortsUploadModal.tsx
+++ b/src/domains/admin/shorts/components/AdminShortsUploadModal.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import {
+  AdminFileUpload,
+  AdminPosterUpload,
+  AdminPublicStatus,
+  AdminTextInput,
+  PosterState,
+} from "@admin-upload";
+import { VideoFileMeta } from "@/types";
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { CommonButton } from "@/components/common";
+import { X } from "lucide-react";
+import AdminOriginalContentsDropdown from "./AdminOriginalContentsDropdown";
+
+interface AdminShortsUploadModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const ORIGINAL_LIST = [
+  "더글로리",
+  "선재 업고 튀어",
+  "흑백 요리사 시즌1",
+  "흑백 요리사 시즌2",
+  "대탈출 1",
+  "대탈출 2",
+  "대탈출 3",
+  "대탈출 4",
+  "대탈출 5",
+];
+export default function AdminShortsUploadModal({
+  open,
+  onClose,
+}: AdminShortsUploadModalProps) {
+  const [mounted, setMounted] = useState<boolean>(false);
+
+  const [title, setTitle] = useState<string>("");
+  const [description, setDescription] = useState<string>("");
+  const [isPublic, setIsPublic] = useState<boolean>(false);
+  const [videoFile, setVideoFile] = useState<VideoFileMeta | null>(null);
+  const [selectedOriginal, setSelectedOriginal] = useState<string | null>(null);
+  const [poster, setPoster] = useState<PosterState>({
+    vertical: null,
+    horizontal: null,
+  });
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open, onClose]);
+
+  useEffect(() => {
+    document.body.style.overflow = open ? "hidden" : "";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  if (!mounted || !open) return null;
+
+  const handleOriginalContentsChange = (original: string | null) => {
+    setSelectedOriginal(original);
+  };
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    console.log("숏폼 업로드 처리 로직");
+  };
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={onClose}
+    >
+      <div
+        className="relative w-218 bg-ot-text rounded-lg py-6 px-8 shadow-xl overflow-y-auto max-h-[90vh]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* 헤더 */}
+        <div className="relative mb-8 text-ot-background">
+          <p className="text-2xl font-bold">숏폼 업로드</p>
+          <button
+            onClick={onClose}
+            className="absolute top-0 right-0 text-ot-background hover:text-ot-gray-600 transition-colors cursor-pointer"
+          >
+            <X size={22} />
+          </button>
+        </div>
+
+        <form
+          className="flex flex-col gap-6 text-ot-background"
+          onSubmit={handleSubmit}
+        >
+          <AdminFileUpload value={videoFile} onChange={setVideoFile} />
+
+          <AdminTextInput
+            label="제목"
+            placeholder="숏폼 제목을 입력하세요"
+            value={title}
+            onChange={setTitle}
+          />
+
+          <AdminTextInput
+            label="설명"
+            placeholder="숏폼 설명을 입력하세요"
+            multiline
+            value={description}
+            onChange={setDescription}
+          />
+
+          {/* 원본콘텐츠·공개여부 + 포스터 */}
+          <div className="grid grid-cols-2 gap-12">
+            {/* 좌측 */}
+            <div className="flex flex-col gap-6">
+              <AdminOriginalContentsDropdown
+                value={selectedOriginal}
+                onChange={handleOriginalContentsChange}
+                originalList={ORIGINAL_LIST}
+              />
+              <AdminPublicStatus isPublic={isPublic} onChange={setIsPublic} />
+            </div>
+
+            {/* 우측 */}
+            <AdminPosterUpload value={poster} onChange={setPoster} isShorts />
+          </div>
+
+          {/* 버튼 */}
+          <div className="grid grid-cols-2 gap-4">
+            <CommonButton
+              type="button"
+              onClick={onClose}
+              className="py-3 font-semibold"
+              variant="outline"
+            >
+              취소
+            </CommonButton>
+            <CommonButton type="submit" className="py-3 font-semibold">
+              업로드 시작
+            </CommonButton>
+          </div>
+        </form>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/domains/admin/shorts/components/index.ts
+++ b/src/domains/admin/shorts/components/index.ts
@@ -1,0 +1,6 @@
+export { default as AdminOriginalContentsDropdown } from "./AdminOriginalContentsDropdown";
+export { default as AdminShortsDetailModal } from "./AdminShortsDetailModal";
+export { default as AdminShortsList } from "./AdminShortsList";
+export { default as AdminShortsSection } from "./AdminShortsSection";
+export { default as AdminShortsUploadButton } from "./AdminShortsUploadButton";
+export { default as AdminShortsUploadModal } from "./AdminShortsUploadModal";

--- a/src/mocks/mockAdminShorts.ts
+++ b/src/mocks/mockAdminShorts.ts
@@ -6,8 +6,8 @@ export interface ShortsType extends VideoFileMeta {
   description: string;
   cast: string[];
   originalContents: {
-    orinalId: number;
-    orinalTitle: string;
+    originalId: number;
+    originalTitle: string;
     category: Category;
     tags: string[];
   };
@@ -24,8 +24,8 @@ export const mockAdminShorts: ShortsType[] = [
     description: "더글로리 시즌1에서 동은이 복수를 결심하는 결정적인 장면.",
     cast: ["송혜교", "이도현"],
     originalContents: {
-      orinalId: 1,
-      orinalTitle: "더 글로리 시즌1",
+      originalId: 1,
+      originalTitle: "더 글로리 시즌1",
       category: "드라마",
       tags: ["스릴러"],
     },
@@ -45,8 +45,8 @@ export const mockAdminShorts: ShortsType[] = [
     description: "범죄도시에서 마석도의 통쾌한 액션 장면을 담은 숏폼.",
     cast: ["마동석"],
     originalContents: {
-      orinalId: 3,
-      orinalTitle: "범죄도시",
+      originalId: 3,
+      originalTitle: "범죄도시",
       category: "영화",
       tags: ["액션"],
     },
@@ -66,8 +66,8 @@ export const mockAdminShorts: ShortsType[] = [
     description: "이상한 변호사 우영우에서 인상 깊었던 변론 장면.",
     cast: ["박은빈"],
     originalContents: {
-      orinalId: 5,
-      orinalTitle: "이상한 변호사 우영우 시즌1",
+      originalId: 5,
+      originalTitle: "이상한 변호사 우영우 시즌1",
       category: "드라마",
       tags: ["법정"],
     },
@@ -87,8 +87,8 @@ export const mockAdminShorts: ShortsType[] = [
     description: "오징어게임에서 참가자들이 첫 번째 게임에 참여하는 장면.",
     cast: ["이정재", "박해수"],
     originalContents: {
-      orinalId: 4,
-      orinalTitle: "오징어 게임 시즌1",
+      originalId: 4,
+      originalTitle: "오징어 게임 시즌1",
       category: "드라마",
       tags: ["스릴러"],
     },

--- a/src/mocks/mockAdminShorts.ts
+++ b/src/mocks/mockAdminShorts.ts
@@ -1,0 +1,105 @@
+import { Category, VideoFileMeta } from "@base-type";
+
+export interface ShortsType extends VideoFileMeta {
+  id: number;
+  title: string;
+  description: string;
+  cast: string[];
+  originalContents: {
+    orinalId: number;
+    orinalTitle: string;
+    category: Category;
+    tags: string[];
+  };
+  isPublic: boolean;
+  uploadDate: string;
+  uploader: string;
+  bookmarkCount: number;
+  thumbnailShorts: string;
+}
+export const mockAdminShorts: ShortsType[] = [
+  {
+    id: 1,
+    title: "동은의 첫 복수 계획",
+    description: "더글로리 시즌1에서 동은이 복수를 결심하는 결정적인 장면.",
+    cast: ["송혜교", "이도현"],
+    originalContents: {
+      orinalId: 1,
+      orinalTitle: "더 글로리 시즌1",
+      category: "드라마",
+      tags: ["스릴러"],
+    },
+    isPublic: true,
+    uploadDate: "2026-02-09",
+    uploader: "에디터_김철수",
+    bookmarkCount: 8543,
+
+    name: "더글로리_shorts_01.mp4",
+    size: 120_000_000, // 약 114MB
+    duration: "00:03:13",
+    thumbnailShorts: "/images/recommendcontent_img.png",
+  },
+  {
+    id: 2,
+    title: "마석도의 한 방",
+    description: "범죄도시에서 마석도의 통쾌한 액션 장면을 담은 숏폼.",
+    cast: ["마동석"],
+    originalContents: {
+      orinalId: 3,
+      orinalTitle: "범죄도시",
+      category: "영화",
+      tags: ["액션"],
+    },
+    isPublic: true,
+    uploadDate: "2026-02-05",
+    uploader: "에디터_이수진",
+    bookmarkCount: 4210,
+
+    name: "범죄도시_shorts_01.mp4",
+    size: 95_000_000, // 약 90MB
+    duration: "00:02:45",
+    thumbnailShorts: "/images/recommendcontent_img.png",
+  },
+  {
+    id: 3,
+    title: "우영우의 법정 명장면",
+    description: "이상한 변호사 우영우에서 인상 깊었던 변론 장면.",
+    cast: ["박은빈"],
+    originalContents: {
+      orinalId: 5,
+      orinalTitle: "이상한 변호사 우영우 시즌1",
+      category: "드라마",
+      tags: ["법정"],
+    },
+    isPublic: false,
+    uploadDate: "2026-01-28",
+    uploader: "에디터_이수진",
+    bookmarkCount: 3120,
+
+    name: "우영우_shorts_01.mp4",
+    size: 110_000_000, // 약 105MB
+    duration: "00:02:58",
+    thumbnailShorts: "/images/recommendcontent_img.png",
+  },
+  {
+    id: 4,
+    title: "오징어게임 첫 게임 시작",
+    description: "오징어게임에서 참가자들이 첫 번째 게임에 참여하는 장면.",
+    cast: ["이정재", "박해수"],
+    originalContents: {
+      orinalId: 4,
+      orinalTitle: "오징어 게임 시즌1",
+      category: "드라마",
+      tags: ["스릴러"],
+    },
+    isPublic: true,
+    uploadDate: "2026-02-01",
+    uploader: "에디터_김철수",
+    bookmarkCount: 9821,
+
+    name: "오징어게임_shorts_01.mp4",
+    size: 140_000_000, // 약 134MB
+    duration: "00:03:40",
+    thumbnailShorts: "/images/recommendcontent_img.png",
+  },
+];

--- a/src/types/videoFileMeta.ts
+++ b/src/types/videoFileMeta.ts
@@ -3,3 +3,4 @@ export interface VideoFileMeta {
   size: number;
   duration: string;
 }
+// file 붙이기

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,6 +33,7 @@
       "@admin-user": ["./src/domains/admin/user/components"],
       "@admin-series": ["./src/domains/admin/series/components"],
       "@admin-contents": ["./src/domains/admin/contents/components"],
+      "@admin-shorts": ["./src/domains/admin/shorts/components"],
       // types
       "@base-type": ["./src/types"],
       "@admin-type": ["./src/types/admin"]


### PR DESCRIPTION
## 📝 작업 내용

> 백오피스 - 숏폼관리 리스트, 상세 정보, 업로드 UI 구현하였습니다.
>   - 콘텐츠 관리, 시리즈 관리와 동일한 UI로 구성되어 있습니다.

### 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. src에 이미지 url만 등록하면 됩니다. -->

| 구현 내용 |             SE              |           13 mini           |
| :-------: | :-------------------------: | :-------------------------: |
|    GIF    | <img src = "https://github.com/user-attachments/assets/6f40ebc0-ae3b-4bf5-9376-bd58aadd5407" width ="400"> | <img src = "https://github.com/user-attachments/assets/537ab8fd-759e-434f-a482-066579e4f933" width ="400"> | 


## 🖥️ 주요 코드 설명


## ☑️ 체크 리스트

> 체크 리스트를 확인해주세요

- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?

## #️⃣ 연관된 이슈

> ex) #50 

## 💬 리뷰 요구사항

> - 코드는 콘텐츠 관리, 시리즈 관리와 유사한 구조라서 디자인 위주로 봐주시면 감사하겠습니다!
> - file upload 관련 타입은 수정 모달 구현할 때 같이 올리겠습니다..


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 관리자 패널에 숏폼 관리 섹션 추가됨
  * 숏폼 업로드 기능 추가 (동영상, 제목/설명, 원본 콘텐츠 선택, 공개/비공개 설정 포함)
  * 숏폼 목록 조회 및 공개/비공개 필터링 기능 추가
  * 숏폼 상세 정보 모달 추가
  * 원본 콘텐츠 검색 드롭다운 추가

* **UX**
  * 숏폼 전용 업로드 시 가로 포스터 업로드 옵션 숨김으로 폼 간소화
  * 드롭다운 커서 포인터 스타일 개선

* **문구**
  * 관리자 콘텐츠 타이틀 설명 문구 일부 수정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->