### PR TITLE
[OT-122] [FEAT]: 백오피스 - 콘텐츠 관리 수정 모달 UI 구현

### DIFF
--- a/src/domains/admin/contents/components/AdminContentsEditModal.tsx
+++ b/src/domains/admin/contents/components/AdminContentsEditModal.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { CommonButton } from "@basecomponent";
+import { X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import {
+  AdminCategoryDropdown,
+  AdminContentTypeSelector,
+  AdminPosterUpload,
+  AdminPublicStatus,
+  AdminSeriesDropdown,
+  AdminTagDropdown,
+  AdminTextInput,
+  PosterState,
+} from "@admin-upload";
+import { Category } from "@/types/category";
+import { AdminContentsDetailType } from "@/types/admin";
+import { ContentType } from "@/types/contents";
+
+const SERIES_LIST = [
+  "시리즈 없음",
+  "더글로리",
+  "선재 업고 튀어",
+  "흑백 요리사 시즌1",
+  "흑백 요리사 시즌2",
+  "대탈출 1",
+];
+
+interface AdminContentsEditModalProps {
+  contents: AdminContentsDetailType;
+  onClose: () => void;
+  onUpdate: (updated: AdminContentsDetailType) => void;
+}
+
+export default function AdminContentsEditModal({
+  contents,
+  onClose,
+  onUpdate,
+}: AdminContentsEditModalProps) {
+  const [title, setTitle] = useState<string>(contents.title);
+  const [description, setDescription] = useState<string>(contents.description);
+  const [cast, setCast] = useState<string>(contents.cast.join(", "));
+  const [isPublic, setIsPublic] = useState<boolean>(contents.isPublic);
+  const [selectedSeries, setSelectedSeries] = useState<string | null>(null);
+  const [selectedCategory, setSelectedCategory] = useState<Category | null>(
+    contents.category,
+  );
+  const [selectedTags, setSelectedTags] = useState<string[]>(contents.tags);
+  const [poster, setPoster] = useState<PosterState>({
+    vertical: contents.thumbnailVertical,
+    horizontal: contents.thumbnailHorizontal,
+  });
+
+  const [contentType, setContentType] = useState<ContentType>(contents.type);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, []);
+
+  const handleCategoryChange = (category: Category | null) => {
+    setSelectedCategory(category);
+    setSelectedTags([]);
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    onUpdate({
+      ...contents,
+      title,
+      description,
+      category: selectedCategory ?? contents.category,
+      tags: selectedTags,
+      isPublic,
+      cast: cast
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean),
+      thumbnailVertical: poster.vertical ?? contents.thumbnailVertical,
+      thumbnailHorizontal: poster.horizontal ?? contents.thumbnailHorizontal,
+    });
+  };
+
+  if (typeof document === "undefined") return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={onClose}
+    >
+      <div
+        className="relative w-218 bg-ot-text rounded-lg py-6 px-8 shadow-xl overflow-y-auto max-h-[90vh]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* 헤더 */}
+        <div className="relative mb-8 text-ot-background">
+          <p className="text-2xl font-bold">콘텐츠 업로드</p>
+          <button
+            onClick={onClose}
+            className="absolute top-0 right-0 text-ot-background hover:text-ot-gray-600 transition-colors cursor-pointer"
+          >
+            <X size={22} />
+          </button>
+        </div>
+
+        <form
+          className="grid gap-y-6 text-ot-background"
+          onSubmit={handleSubmit}
+        >
+          <AdminContentTypeSelector
+            value={contentType}
+            onChange={setContentType}
+          />
+
+          <AdminTextInput
+            label="제목"
+            placeholder='콘텐츠 제목을 입력하세요 (예: "시리즈명: 1화")'
+            value={title}
+            onChange={setTitle}
+          />
+
+          <AdminTextInput
+            label="설명"
+            placeholder="콘텐츠 설명을 입력하세요"
+            multiline
+            value={description}
+            onChange={setDescription}
+          />
+
+          <AdminTextInput
+            label="출연"
+            placeholder="출연진은 쉼표(,)로 구분해 입력해 주세요 (예: 임지연, 송혜교, 이도현 · 최대 4인)"
+            value={cast}
+            onChange={setCast}
+          />
+
+          {/* 시리즈 + 공개 여부 */}
+          <div className="grid grid-cols-2 gap-6">
+            {contentType === "시리즈" ? (
+              <AdminSeriesDropdown
+                seriesList={SERIES_LIST}
+                value={selectedSeries}
+                onChange={setSelectedSeries}
+              />
+            ) : (
+              <AdminSeriesDropdown
+                seriesList={SERIES_LIST}
+                value={selectedSeries}
+                onChange={setSelectedSeries}
+                disabled
+              />
+            )}
+            <AdminPublicStatus isPublic={isPublic} onChange={setIsPublic} />
+          </div>
+
+          {/* 카테고리 + 태그 */}
+          <div className="grid grid-cols-2 gap-6">
+            <AdminCategoryDropdown
+              value={selectedCategory}
+              onChange={handleCategoryChange}
+            />
+            <AdminTagDropdown
+              category={selectedCategory}
+              value={selectedTags}
+              onChange={setSelectedTags}
+            />
+          </div>
+
+          <AdminPosterUpload value={poster} onChange={setPoster} />
+
+          {/* 버튼 */}
+          <div className="grid grid-cols-2 gap-4">
+            <CommonButton
+              type="button"
+              onClick={onClose}
+              className="py-3 font-semibold"
+              variant="outline"
+            >
+              취소
+            </CommonButton>
+            <CommonButton type="submit" className="py-3 font-semibold">
+              수정 완료
+            </CommonButton>
+          </div>
+        </form>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/domains/admin/contents/components/AdminContentsEditModal.tsx
+++ b/src/domains/admin/contents/components/AdminContentsEditModal.tsx
@@ -20,7 +20,7 @@ import { ContentType } from "@/types/contents";
 
 const SERIES_LIST = [
   "시리즈 없음",
-  "더글로리",
+  "더글로리 시즌1",
   "선재 업고 튀어",
   "흑백 요리사 시즌1",
   "흑백 요리사 시즌2",
@@ -42,7 +42,9 @@ export default function AdminContentsEditModal({
   const [description, setDescription] = useState<string>(contents.description);
   const [cast, setCast] = useState<string>(contents.cast.join(", "));
   const [isPublic, setIsPublic] = useState<boolean>(contents.isPublic);
-  const [selectedSeries, setSelectedSeries] = useState<string | null>(null);
+  const [selectedSeries, setSelectedSeries] = useState<string | null>(
+    contents.seriesTitle,
+  );
   const [selectedCategory, setSelectedCategory] = useState<Category | null>(
     contents.category,
   );

--- a/src/domains/admin/contents/components/AdminContentsEditModal.tsx
+++ b/src/domains/admin/contents/components/AdminContentsEditModal.tsx
@@ -80,6 +80,8 @@ export default function AdminContentsEditModal({
     e.preventDefault();
     onUpdate({
       ...contents,
+      type: contentType,
+      seriesTitle: contentType === "시리즈" ? selectedSeries : null,
       title,
       description,
       category: selectedCategory ?? contents.category,
@@ -107,7 +109,7 @@ export default function AdminContentsEditModal({
       >
         {/* 헤더 */}
         <div className="relative mb-8 text-ot-background">
-          <p className="text-2xl font-bold">콘텐츠 업로드</p>
+          <p className="text-2xl font-bold">콘텐츠 정보 수정</p>
           <button
             onClick={onClose}
             className="absolute top-0 right-0 text-ot-background hover:text-ot-gray-600 transition-colors cursor-pointer"

--- a/src/domains/admin/contents/components/AdminContentsList.tsx
+++ b/src/domains/admin/contents/components/AdminContentsList.tsx
@@ -24,7 +24,7 @@ export default function AdminContentsList({
     useState<AdminContentsDetailType[]>(mockAdminContents);
 
   const filteredData = filterPublic
-    ? mockAdminContents.filter((content) =>
+    ? data.filter((content) =>
         filterPublic === "공개" ? content.isPublic : !content.isPublic,
       )
     : data;

--- a/src/domains/admin/contents/components/AdminContentsList.tsx
+++ b/src/domains/admin/contents/components/AdminContentsList.tsx
@@ -6,7 +6,12 @@ import { Edit } from "lucide-react";
 import Image from "next/image";
 import { PublicType } from "@/types/admin/adminPublic";
 import { useRouter, useSearchParams } from "next/navigation";
-import { AdminContentsDetailModal } from "@admin-contents";
+import {
+  AdminContentsDetailModal,
+  AdminContentsEditModal,
+} from "@admin-contents";
+import { AdminContentsDetailType } from "@/types/admin";
+import { useState } from "react";
 
 interface AdminContentsListProps {
   filterPublic?: PublicType | null;
@@ -15,16 +20,21 @@ interface AdminContentsListProps {
 export default function AdminContentsList({
   filterPublic,
 }: AdminContentsListProps) {
-  const data = filterPublic
+  const [data, setData] =
+    useState<AdminContentsDetailType[]>(mockAdminContents);
+
+  const filteredData = filterPublic
     ? mockAdminContents.filter((content) =>
         filterPublic === "공개" ? content.isPublic : !content.isPublic,
       )
-    : mockAdminContents;
+    : data;
 
   const router = useRouter();
   const searchParams = useSearchParams();
 
   const selectedId = searchParams.get("id");
+  const action = searchParams.get("action");
+
   const selectedContents = selectedId
     ? (data.find((s) => s.id === Number(selectedId)) ?? null)
     : null;
@@ -35,6 +45,15 @@ export default function AdminContentsList({
 
   const handleClose = () => {
     router.push("?", { scroll: false });
+  };
+
+  const handleEditClick = (id: number) => {
+    router.push(`?id=${id}&action=edit`, { scroll: false });
+  };
+
+  const handleUpdate = (updated: AdminContentsDetailType) => {
+    setData((prev) => prev.map((c) => (c.id === updated.id ? updated : c)));
+    handleClose();
   };
 
   return (
@@ -60,7 +79,7 @@ export default function AdminContentsList({
           </thead>
 
           <tbody className="bg-ot-gray-700 divide-y divide-ot-gray-800">
-            {data.map((content) => (
+            {filteredData.map((content) => (
               <tr
                 key={content.id}
                 onClick={() => handleRowClick(content.id)}
@@ -106,9 +125,15 @@ export default function AdminContentsList({
                   {content.uploadDate}
                 </td>
 
-                <td className="py-3 text-center ">
-                  <button onClick={(e) => e.stopPropagation()}>
-                    <Edit size={20} className="hover:stroke-ot-gray-600" />
+                <td
+                  className="py-3 text-center"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <button onClick={() => handleEditClick(content.id)}>
+                    <Edit
+                      size={20}
+                      className="hover:stroke-ot-gray-600 cursor-pointer"
+                    />
                   </button>
                 </td>
               </tr>
@@ -116,10 +141,21 @@ export default function AdminContentsList({
           </tbody>
         </table>
       </div>
-      <AdminContentsDetailModal
-        contents={selectedContents}
-        onClose={handleClose}
-      />
+
+      {action === "edit" && selectedContents ? (
+        <AdminContentsEditModal
+          contents={selectedContents}
+          onClose={handleClose}
+          onUpdate={handleUpdate}
+        />
+      ) : (
+        selectedContents && (
+          <AdminContentsDetailModal
+            contents={selectedContents}
+            onClose={handleClose}
+          />
+        )
+      )}
     </>
   );
 }

--- a/src/domains/admin/contents/components/index.ts
+++ b/src/domains/admin/contents/components/index.ts
@@ -2,3 +2,4 @@ export { default as AdminContentsUploadModal } from "./AdminContentsUploadModal"
 export { default as AdminContentsDetailModal } from "./AdminContentsDetailModal";
 export { default as UploadButton } from "./UploadButton";
 export { default as AdminContentsList } from "./AdminContentsList";
+export { default as AdminContentsEditModal } from "./AdminContentsEditModal";


### PR DESCRIPTION
## 📝 작업 내용

> - 백오피스 - 콘텐츠 관리 수정 모달 UI 구현했습니다.
> - 시리즈 관리의 수정모달과 코드 구조 동일합니다.
> - 수정/업로드 할 때 시리즈를 선택하면, 카테고리-태그는 자동선택 되도록 구현할 것입니다. (추후 API 연동 시 구현 예정)
 
### 📷 스크린샷

https://github.com/user-attachments/assets/82f9a9cb-2683-444b-9c86-c11fba287670



## 🖥️ 주요 코드 설명


## ☑️ 체크 리스트

> 체크 리스트를 확인해주세요

- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?

## #️⃣ 연관된 이슈

> ex) #56 

## 💬 리뷰 요구사항




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 콘텐츠 편집 모달 추가 — 제목, 설명, 출연진, 시리즈, 카테고리, 태그, 포스터, 콘텐츠 유형, 공개 여부 편집 가능
  * 시리즈 선택은 콘텐츠 유형에 따라 조건부 표시/비활성화
  * 카테고리 변경 시 태그 초기화, 포스터/썸네일 대체 처리
  * Esc 키 및 배경 클릭으로 모달 닫기, 편집 결과가 목록에 즉시 반영됩니니다
<!-- end of auto-generated comment: release notes by coderabbit.ai -->