### PR TITLE
[OT-126] [FEAT]: 백오피스 - 숏폼 관리 수정 모달 UI 구현

### DIFF
--- a/src/components/admin/common/upload/AdminPosterUpload.tsx
+++ b/src/components/admin/common/upload/AdminPosterUpload.tsx
@@ -6,7 +6,7 @@ import { useRef } from "react";
 
 export interface PosterState {
   vertical: string | null;
-  horizontal: string | null;
+  horizontal?: string | null;
 }
 
 export interface AdminPosterUploadProps {

--- a/src/domains/admin/shorts/components/AdminShortsEditModal.tsx
+++ b/src/domains/admin/shorts/components/AdminShortsEditModal.tsx
@@ -1,23 +1,17 @@
 "use client";
 
+import { CommonButton } from "@basecomponent";
+import { X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import {
-  AdminFileUpload,
   AdminPosterUpload,
   AdminPublicStatus,
   AdminTextInput,
   PosterState,
 } from "@admin-upload";
-import { VideoFileMeta } from "@/types";
-import { useEffect, useState } from "react";
-import { createPortal } from "react-dom";
-import { CommonButton } from "@/components/common";
-import { X } from "lucide-react";
 import { AdminOriginalContentsDropdown } from "@admin-shorts";
-
-interface AdminShortsUploadModalProps {
-  open: boolean;
-  onClose: () => void;
-}
+import { ShortsType } from "@/mocks/mockAdminShorts";
 
 const ORIGINAL_LIST = [
   "더글로리",
@@ -30,50 +24,60 @@ const ORIGINAL_LIST = [
   "대탈출 4",
   "대탈출 5",
 ];
-export default function AdminShortsUploadModal({
-  open,
+
+interface AdminShortsEditModalProps {
+  shorts: ShortsType;
+  onClose: () => void;
+  onUpdate: (updated: ShortsType) => void;
+}
+
+export default function AdminShortsEditModal({
+  shorts,
   onClose,
-}: AdminShortsUploadModalProps) {
-  const [mounted, setMounted] = useState<boolean>(false);
-
-  const [title, setTitle] = useState<string>("");
-  const [description, setDescription] = useState<string>("");
-  const [isPublic, setIsPublic] = useState<boolean>(false);
-  const [videoFile, setVideoFile] = useState<VideoFileMeta | null>(null);
-  const [selectedOriginal, setSelectedOriginal] = useState<string | null>(null);
+  onUpdate,
+}: AdminShortsEditModalProps) {
+  const [title, setTitle] = useState<string>(shorts.title);
+  const [description, setDescription] = useState<string>(shorts.description);
+  const [selectedOriginal, setSelectedOriginal] = useState<string | null>(
+    shorts.originalContents.originalTitle,
+  );
+  const [isPublic, setIsPublic] = useState<boolean>(shorts.isPublic);
   const [poster, setPoster] = useState<PosterState>({
-    vertical: null,
-    horizontal: null,
+    vertical: shorts.thumbnailShorts,
   });
-  useEffect(() => {
-    setMounted(true);
-  }, []);
 
   useEffect(() => {
-    if (!open) return;
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [open, onClose]);
+  }, [onClose]);
 
   useEffect(() => {
-    document.body.style.overflow = open ? "hidden" : "";
+    document.body.style.overflow = "hidden";
     return () => {
       document.body.style.overflow = "";
     };
-  }, [open]);
-
-  if (!mounted || !open) return null;
+  }, []);
 
   const handleOriginalContentsChange = (original: string | null) => {
     setSelectedOriginal(original);
   };
+
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    console.log("숏폼 업로드 처리 로직");
+    onUpdate({
+      ...shorts,
+      title,
+      description,
+      originalContents: shorts.originalContents,
+      isPublic,
+      thumbnailShorts: poster.vertical ?? shorts.thumbnailShorts,
+    });
   };
+
+  if (typeof document === "undefined") return null;
 
   return createPortal(
     <div
@@ -86,7 +90,7 @@ export default function AdminShortsUploadModal({
       >
         {/* 헤더 */}
         <div className="relative mb-8 text-ot-background">
-          <p className="text-2xl font-bold">숏폼 정보 수정</p>
+          <p className="text-2xl font-bold">숏폼 업로드</p>
           <button
             onClick={onClose}
             className="absolute top-0 right-0 text-ot-background hover:text-ot-gray-600 transition-colors cursor-pointer"
@@ -99,8 +103,6 @@ export default function AdminShortsUploadModal({
           className="flex flex-col gap-6 text-ot-background"
           onSubmit={handleSubmit}
         >
-          <AdminFileUpload value={videoFile} onChange={setVideoFile} />
-
           <AdminTextInput
             label="제목"
             placeholder="숏폼 제목을 입력하세요"
@@ -143,7 +145,7 @@ export default function AdminShortsUploadModal({
               취소
             </CommonButton>
             <CommonButton type="submit" className="py-3 font-semibold">
-              수정 완료
+              업로드 시작
             </CommonButton>
           </div>
         </form>

--- a/src/domains/admin/shorts/components/AdminShortsEditModal.tsx
+++ b/src/domains/admin/shorts/components/AdminShortsEditModal.tsx
@@ -71,7 +71,11 @@ export default function AdminShortsEditModal({
       ...shorts,
       title,
       description,
-      originalContents: shorts.originalContents,
+      originalContents: {
+        ...shorts.originalContents,
+        originalTitle:
+          selectedOriginal ?? shorts.originalContents.originalTitle,
+      },
       isPublic,
       thumbnailShorts: poster.vertical ?? shorts.thumbnailShorts,
     });
@@ -90,7 +94,7 @@ export default function AdminShortsEditModal({
       >
         {/* 헤더 */}
         <div className="relative mb-8 text-ot-background">
-          <p className="text-2xl font-bold">숏폼 업로드</p>
+          <p className="text-2xl font-bold">숏폼 정보 수정</p>
           <button
             onClick={onClose}
             className="absolute top-0 right-0 text-ot-background hover:text-ot-gray-600 transition-colors cursor-pointer"
@@ -145,7 +149,7 @@ export default function AdminShortsEditModal({
               취소
             </CommonButton>
             <CommonButton type="submit" className="py-3 font-semibold">
-              업로드 시작
+              수정 완료
             </CommonButton>
           </div>
         </form>

--- a/src/domains/admin/shorts/components/AdminShortsList.tsx
+++ b/src/domains/admin/shorts/components/AdminShortsList.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { mockAdminShorts } from "@/mocks/mockAdminShorts";
+import { mockAdminShorts, ShortsType } from "@/mocks/mockAdminShorts";
 import { PublicType } from "@/types/admin";
 import { AdminBadge } from "@admin-basecomponent";
 import { Edit } from "lucide-react";
@@ -7,6 +7,8 @@ import Image from "next/image";
 
 import { useRouter, useSearchParams } from "next/navigation";
 import { AdminShortsDetailModal } from "@admin-shorts";
+import { useState } from "react";
+import AdminShortsEditModal from "./AdminShortsEditModal";
 
 interface AdminShortsListProps {
   filterPublic?: PublicType | null;
@@ -15,16 +17,20 @@ interface AdminShortsListProps {
 export default function AdminShortsList({
   filterPublic,
 }: AdminShortsListProps) {
-  const data = filterPublic
-    ? mockAdminShorts.filter((short) =>
+  const [data, setData] = useState<ShortsType[]>(mockAdminShorts);
+
+  const filteredData = filterPublic
+    ? data.filter((short) =>
         filterPublic === "공개" ? short.isPublic : !short.isPublic,
       )
-    : mockAdminShorts;
+    : data;
 
   const router = useRouter();
   const searchParams = useSearchParams();
 
   const selectedId = searchParams.get("id");
+  const action = searchParams.get("action");
+
   const selectedshorts = selectedId
     ? (data.find((s) => s.id === Number(selectedId)) ?? null)
     : null;
@@ -35,6 +41,15 @@ export default function AdminShortsList({
 
   const handleClose = () => {
     router.push("?", { scroll: false });
+  };
+
+  const handleEditClick = (id: number) => {
+    router.push(`?id=${id}&action=edit`, { scroll: false });
+  };
+
+  const handleUpdate = (updated: ShortsType) => {
+    setData((prev) => prev.map((c) => (c.id === updated.id ? updated : c)));
+    handleClose();
   };
 
   return (
@@ -60,7 +75,7 @@ export default function AdminShortsList({
           </thead>
 
           <tbody className="bg-ot-gray-700 divide-y divide-ot-gray-800">
-            {data.map((short) => (
+            {filteredData.map((short) => (
               <tr
                 key={short.id}
                 onClick={() => handleRowClick(short.id)}
@@ -106,9 +121,15 @@ export default function AdminShortsList({
                   {short.uploadDate}
                 </td>
 
-                <td className="py-3 text-center ">
-                  <button onClick={(e) => e.stopPropagation()}>
-                    <Edit size={20} className="hover:stroke-ot-gray-600" />
+                <td
+                  className="py-3 text-center"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <button onClick={() => handleEditClick(short.id)}>
+                    <Edit
+                      size={20}
+                      className="hover:stroke-ot-gray-600 cursor-pointer"
+                    />
                   </button>
                 </td>
               </tr>
@@ -116,7 +137,20 @@ export default function AdminShortsList({
           </tbody>
         </table>
       </div>
-      <AdminShortsDetailModal shorts={selectedshorts} onClose={handleClose} />
+      {action === "edit" && selectedshorts ? (
+        <AdminShortsEditModal
+          shorts={selectedshorts}
+          onClose={handleClose}
+          onUpdate={handleUpdate}
+        />
+      ) : (
+        selectedshorts && (
+          <AdminShortsDetailModal
+            shorts={selectedshorts}
+            onClose={handleClose}
+          />
+        )
+      )}
     </>
   );
 }

--- a/src/domains/admin/shorts/components/AdminShortsUploadModal.tsx
+++ b/src/domains/admin/shorts/components/AdminShortsUploadModal.tsx
@@ -86,7 +86,7 @@ export default function AdminShortsUploadModal({
       >
         {/* 헤더 */}
         <div className="relative mb-8 text-ot-background">
-          <p className="text-2xl font-bold">숏폼 정보 수정</p>
+          <p className="text-2xl font-bold">숏폼 업로드</p>
           <button
             onClick={onClose}
             className="absolute top-0 right-0 text-ot-background hover:text-ot-gray-600 transition-colors cursor-pointer"
@@ -143,7 +143,7 @@ export default function AdminShortsUploadModal({
               취소
             </CommonButton>
             <CommonButton type="submit" className="py-3 font-semibold">
-              수정 완료
+              업로드 시작
             </CommonButton>
           </div>
         </form>

--- a/src/domains/admin/shorts/components/index.ts
+++ b/src/domains/admin/shorts/components/index.ts
@@ -4,3 +4,4 @@ export { default as AdminShortsList } from "./AdminShortsList";
 export { default as AdminShortsSection } from "./AdminShortsSection";
 export { default as AdminShortsUploadButton } from "./AdminShortsUploadButton";
 export { default as AdminShortsUploadModal } from "./AdminShortsUploadModal";
+export { default as AdminShortsEditModal } from "./AdminShortsEditModal";


### PR DESCRIPTION
## 📝 작업 내용

> 백오피스 - 숏폼 관리 수정 모달 UI 구현했습니다.

### 📷 스크린샷

https://github.com/user-attachments/assets/0f6bd61a-0d62-4707-985a-4e97db03fb7d


## 🖥️ 주요 코드 설명


## ☑️ 체크 리스트

> 체크 리스트를 확인해주세요

- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?

## #️⃣ 연관된 이슈

> ex) #56 

## 💬 리뷰 요구사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 숏츠(Shorts) 편집 모달 UI 추가: 제목, 설명, 원본 콘텐츠, 공개 여부, 포스터 등을 한 곳에서 편집 가능
  * 숏츠 목록에서 편집 버튼 활성화: 클릭 시 모달 편집 화면으로 이동
  * 모달 제출 시 변경사항 실시간 반영 기능 추가
  * 배경 스크롤 방지 및 Escape 키로 모달 닫기 지원
<!-- end of auto-generated comment: release notes by coderabbit.ai -->