### PR TITLE
[OT-195] [FEAT]: 마이페이지 내 댓글목록 조회 & 삭제 API 연동

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,10 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       {
         protocol: "https",
+        hostname: "oplust-content-0370aace.s3.ap-northeast-2.amazonaws.com",
+      },
+      {
+        protocol: "https",
         hostname: "cdn.ott.com",
       },
     ],

--- a/src/entities/custom/constants/factors.ts
+++ b/src/entities/custom/constants/factors.ts
@@ -31,8 +31,8 @@ export const GUIDE_ITEMS: { key: Factor; en: string; desc: string }[] = [
   },
   {
     key: "재시청률",
-    en: "Short-form Hot",
-    desc: "현재 O+T 숏폼에서 가장 뜨거운 반응을 얻고 있는 화제의 작품을 추천합니다.",
+    en: "Rewatch Rate",
+    desc: "다시 보고 싶을 만큼 만족도가 높은 작품을 우선으로 추천합니다.",
   },
 ];
 

--- a/src/entities/custom/constants/factors.ts
+++ b/src/entities/custom/constants/factors.ts
@@ -1,13 +1,13 @@
-export type Factor = "대중성" | "몰입도" | "마니아" | "최신성" | "숏폼 트렌드";
+export type Factor = "대중성" | "몰입도" | "마니아" | "최신성" | "재시청률";
 
-export const FACTORS: Factor[] = ["대중성", "몰입도", "마니아", "최신성", "숏폼 트렌드"];
+export const FACTORS: Factor[] = ["대중성", "몰입도", "마니아", "최신성", "재시청률"];
 
 export const INITIAL_VALUES: Record<Factor, number> = {
   대중성: 0,
   몰입도: 0,
   마니아: 0,
   최신성: 0,
-  "숏폼 트렌드": 0,
+  재시청률: 0,
 };
 
 export const GENRES = ["인기작 위주", "숨은 명작", "초기화"];
@@ -30,7 +30,7 @@ export const GUIDE_ITEMS: { key: Factor; en: string; desc: string }[] = [
     desc: "지금 막 올라온 따끈따끈한 신규 콘텐츠를 빠르게 만나볼 수 있습니다.",
   },
   {
-    key: "숏폼 트렌드",
+    key: "재시청률",
     en: "Short-form Hot",
     desc: "현재 O+T 숏폼에서 가장 뜨거운 반응을 얻고 있는 화제의 작품을 추천합니다.",
   },

--- a/src/entities/custom/constants/presets.ts
+++ b/src/entities/custom/constants/presets.ts
@@ -17,7 +17,7 @@ export const CUSTOM_PRESETS: Record<string, Preset> = {
       몰입도: 10,
       마니아: 20,
       최신성: 20,
-      "숏폼 트렌드": 10,
+      재시청률: 10,
     },
   },
   HIDDEN_GEM: {
@@ -29,7 +29,7 @@ export const CUSTOM_PRESETS: Record<string, Preset> = {
       몰입도: 30,
       마니아: 45,
       최신성: 10,
-      "숏폼 트렌드": 10,
+      재시청률: 10,
     },
   },
   RESET: {

--- a/src/entities/myreview/api/index.ts
+++ b/src/entities/myreview/api/index.ts
@@ -1,0 +1,2 @@
+export { myreviewApi } from "./myreviewApi";
+export { myreviewDeleteApi } from "./myreviewDeleteApi";

--- a/src/entities/myreview/api/myreviewApi.ts
+++ b/src/entities/myreview/api/myreviewApi.ts
@@ -1,0 +1,9 @@
+import { api } from "@shared/api";
+import { ApiResponse, MyReviewListResponse } from "@shared/types";
+
+export const myreviewApi = {
+  getMyReviews: async (page: number) =>
+    await api.get<ApiResponse<MyReviewListResponse>>("/comments/me", {
+      params: { page, size: 20 },
+    }),
+};

--- a/src/entities/myreview/api/myreviewDeleteApi.ts
+++ b/src/entities/myreview/api/myreviewDeleteApi.ts
@@ -1,0 +1,5 @@
+import { api } from "@shared/api";
+
+export const myreviewDeleteApi = {
+  postMyreviewDelete: async (commentId: number) => await api.delete(`/comments/${commentId}`),
+};

--- a/src/entities/myreview/hooks/index.ts
+++ b/src/entities/myreview/hooks/index.ts
@@ -1,0 +1,2 @@
+export { useMyreviews } from "./useMyreviews";
+export { useDeleteMyreview } from "./useDeleteMyreview";

--- a/src/entities/myreview/hooks/useDeleteMyreview.ts
+++ b/src/entities/myreview/hooks/useDeleteMyreview.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { myreviewDeleteApi } from "@entities/myreview/api";
+
+export function useDeleteMyreview() {
+  const queryClient = useQueryClient();
+  const { mutate, isPending } = useMutation({
+    mutationFn: (commentId: number) => myreviewDeleteApi.postMyreviewDelete(commentId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["myreviews"] });
+    },
+    onError: (err) => {
+      console.error("댓글 삭제 실패:", err);
+    },
+  });
+  return { mutate, isPending };
+}

--- a/src/entities/myreview/hooks/useMyreviews.ts
+++ b/src/entities/myreview/hooks/useMyreviews.ts
@@ -1,0 +1,17 @@
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { myreviewApi } from "@entities/myreview/api";
+
+export function useMyreviews() {
+  return useInfiniteQuery({
+    queryKey: ["myreviews"],
+    queryFn: async ({ pageParam = 0 }) => {
+      const res = await myreviewApi.getMyReviews(pageParam);
+      return res.data.data;
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => {
+      const { currentPage, totalPage } = lastPage.pageInfo;
+      return currentPage + 1 < totalPage ? currentPage + 1 : undefined;
+    },
+  });
+}

--- a/src/features/mypage/components/MyReviewModal.tsx
+++ b/src/features/mypage/components/MyReviewModal.tsx
@@ -4,9 +4,10 @@ import { useEffect, useState, useRef } from "react";
 import { createPortal } from "react-dom";
 import Image from "next/image";
 import { X } from "lucide-react";
-import { mockReviews } from "@shared/mocks/mockReviews";
 import { ConfirmModal } from "@base-components";
 import { useOutsideClick } from "@shared/hooks/useOutsideClick";
+import { useMyreviews } from "@/entities/myreview/hooks";
+import { useDeleteMyreview } from "@/entities/myreview/hooks";
 
 interface MyReviewModalProps {
   isOpen: boolean;
@@ -20,6 +21,11 @@ export default function MyReviewModal({ isOpen, onClose }: MyReviewModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
   const deleteTargetIdRef = useRef<number | null>(null);
   deleteTargetIdRef.current = deleteTargetId; // 항상 최신 값 동기화
+
+  const { data, isLoading, isError } = useMyreviews();
+  const { mutate: deleteComment, isPending } = useDeleteMyreview();
+
+  const reviews = data?.pages.flatMap((page) => page.dataList) ?? [];
 
   useOutsideClick(modalRef, onClose, isOpen && deleteTargetId === null); // 관련 hook 추가하여 사용
 
@@ -59,6 +65,13 @@ export default function MyReviewModal({ isOpen, onClose }: MyReviewModalProps) {
     onClose();
   };
 
+  const handleConfirmDelete = () => {
+    if (deleteTargetId === null) return;
+    deleteComment(deleteTargetId, {
+      onSuccess: closeConfirmModal,
+    });
+  };
+
   return createPortal(
     <div className="fixed inset-0 z-9999 flex items-center justify-center bg-black/50">
       <div
@@ -74,21 +87,31 @@ export default function MyReviewModal({ isOpen, onClose }: MyReviewModalProps) {
         </button>
 
         <div className="flex-1 mt-25 mx-15 mb-15 overflow-y-auto no-scrollbar">
-          {mockReviews.length === 0 ? (
+          {isLoading ? (
+            <div className="flex items-center justify-center h-full">
+              <p className="text-ot-text">로딩 중 ~</p>
+            </div>
+          ) : isError ? (
+            <div className="flex items-center justify-center h-full">
+              <p className="text-ot-gray-600">
+                댓글을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
+              </p>
+            </div>
+          ) : reviews.length === 0 ? (
             <div className="flex items-center justify-center">
               <p className="text-ot-gray-600">작성한 댓글이 없습니다.</p>
             </div>
           ) : (
             <div className="flex flex-col gap-5">
-              {mockReviews.map((review) => (
+              {reviews.map((review) => (
                 <div
-                  key={review.id}
+                  key={review.commentId}
                   className="relative flex items-start w-full gap-5 shrink-0"
                 >
                   {/* 왼쪽 댓글단 작품 이미지 (16 : 9) */}
                   <div className="relative shrink-0 w-45 aspect-video bg-black rounded overflow-hidden">
                     <Image
-                      src={review.image}
+                      src={review.contentsPosterUrl}
                       alt="Review"
                       fill
                       className="object-cover"
@@ -102,16 +125,16 @@ export default function MyReviewModal({ isOpen, onClose }: MyReviewModalProps) {
 
                     {/* 작성자 & 작성 날짜 */}
                     <div className="flex items-center gap-1 text-[14px] text-ot-gray-400">
-                      <span>{review.userId}</span>
+                      <span>{review.writerNickname}</span>
                       <span>·</span>
-                      <span>{review.date}</span>
+                      <span>{review.createdDate}</span>
                     </div>
                   </div>
 
                   {/* 댓글별 삭제 버튼 */}
                   <button
                     className="absolute top-0 right-0 text-ot-gray-400 hover:text-ot-gray-600 cursor-pointer"
-                    onClick={() => handleDeleteClick(review.id)}
+                    onClick={() => handleDeleteClick(review.commentId)}
                   >
                     <X size={16} />
                   </button>
@@ -124,8 +147,9 @@ export default function MyReviewModal({ isOpen, onClose }: MyReviewModalProps) {
       <ConfirmModal
         isOpen={deleteTargetId !== null}
         message="댓글을 삭제하시겠습니까?"
-        onConfirm={closeConfirmModal} // 아직 그냥 닫히기만 함
-        onClose={closeConfirmModal} // 아직 그냥 닫히기만 함
+        onConfirm={handleConfirmDelete}
+        onClose={closeConfirmModal}
+        disabled={isPending}
       />
     </div>,
     document.body,

--- a/src/features/mypage/components/MyReviewModal.tsx
+++ b/src/features/mypage/components/MyReviewModal.tsx
@@ -6,8 +6,9 @@ import Image from "next/image";
 import { X } from "lucide-react";
 import { ConfirmModal } from "@base-components";
 import { useOutsideClick } from "@shared/hooks/useOutsideClick";
-import { useMyreviews } from "@/entities/myreview/hooks";
-import { useDeleteMyreview } from "@/entities/myreview/hooks";
+import { useMyreviews } from "@entities/myreview/hooks";
+import { useDeleteMyreview } from "@entities/myreview/hooks";
+import { formatDate } from "@shared/lib";
 
 interface MyReviewModalProps {
   isOpen: boolean;
@@ -106,7 +107,7 @@ export default function MyReviewModal({ isOpen, onClose }: MyReviewModalProps) {
               {reviews.map((review) => (
                 <div
                   key={review.commentId}
-                  className="relative group flex items-start w-full gap-5 shrink-0 p-4 rounded-xl hover:bg-ot-gray-700 transition-all duration-200 cursor-pointer"
+                  className="relative group flex items-center w-full gap-5 shrink-0 p-4 rounded-xl hover:bg-ot-gray-700 transition-all duration-200 cursor-pointer"
                 >
                   {/* 왼쪽 댓글단 작품 이미지 (16 : 9) */}
                   <div className="relative shrink-0 w-45 aspect-video bg-black rounded overflow-hidden">
@@ -119,15 +120,17 @@ export default function MyReviewModal({ isOpen, onClose }: MyReviewModalProps) {
                   </div>
 
                   {/* 텍스트 영역 */}
-                  <div className="flex flex-col flex-1 pt-4 pr-8 gap-1">
+                  <div className="flex flex-col flex-1 pr-8">
                     {/* 작성한 댓글 내용 */}
-                    <p className="text-ot-text text-[16px]">{review.content}</p>
+                    <div className="flex gap-3 flex-col justify-center">
+                      <p className="text-ot-text text-sm">{review.content}</p>
 
-                    {/* 작성자 & 작성 날짜 */}
-                    <div className="flex items-center gap-1 text-[14px] text-ot-gray-400">
-                      <span>{review.writerNickname}</span>
-                      <span>·</span>
-                      <span>{review.createdDate}</span>
+                      {/* 작성자 & 작성 날짜 */}
+                      <div className="flex items-center gap-1 text-xs text-ot-gray-600">
+                        {/* <span>{review.writerNickname}</span> */}
+                        {/* <span>·</span> */}
+                        <span>{formatDate(review.createdDate)}</span>
+                      </div>
                     </div>
                   </div>
 

--- a/src/features/mypage/components/MyReviewModal.tsx
+++ b/src/features/mypage/components/MyReviewModal.tsx
@@ -86,7 +86,7 @@ export default function MyReviewModal({ isOpen, onClose }: MyReviewModalProps) {
           <X size={24} strokeWidth={2} />
         </button>
 
-        <div className="flex-1 mt-25 mx-15 mb-15 overflow-y-auto no-scrollbar">
+        <div className="flex-1 mt-15 mx-15 mb-10 overflow-y-auto no-scrollbar">
           {isLoading ? (
             <div className="flex items-center justify-center h-full">
               <p className="text-ot-text">로딩 중 ~</p>
@@ -102,11 +102,11 @@ export default function MyReviewModal({ isOpen, onClose }: MyReviewModalProps) {
               <p className="text-ot-gray-600">작성한 댓글이 없습니다.</p>
             </div>
           ) : (
-            <div className="flex flex-col gap-5">
+            <div className="flex flex-col gap-3">
               {reviews.map((review) => (
                 <div
                   key={review.commentId}
-                  className="relative flex items-start w-full gap-5 shrink-0"
+                  className="relative group flex items-start w-full gap-5 shrink-0 p-4 rounded-xl hover:bg-ot-gray-700 transition-all duration-200 cursor-pointer"
                 >
                   {/* 왼쪽 댓글단 작품 이미지 (16 : 9) */}
                   <div className="relative shrink-0 w-45 aspect-video bg-black rounded overflow-hidden">
@@ -133,7 +133,7 @@ export default function MyReviewModal({ isOpen, onClose }: MyReviewModalProps) {
 
                   {/* 댓글별 삭제 버튼 */}
                   <button
-                    className="absolute top-0 right-0 text-ot-gray-400 hover:text-ot-gray-600 cursor-pointer"
+                    className="absolute top-2 right-2 p-2 text-ot-gray-400 hover:text-ot-gray-600 cursor-pointer"
                     onClick={() => handleDeleteClick(review.commentId)}
                   >
                     <X size={16} />

--- a/src/shared/lib/formatDate.ts
+++ b/src/shared/lib/formatDate.ts
@@ -1,5 +1,9 @@
 export const formatDate = (dateString: string) => {
-  const date = new Date(dateString);
+  const utcString = dateString.endsWith("Z") ? dateString : dateString + "Z";
+  const date = new Date(utcString);
+
+  if (Number.isNaN(date.getTime())) return dateString;
+
   return (
     date
       .toLocaleDateString("ko-KR", {

--- a/src/shared/lib/formatDate.ts
+++ b/src/shared/lib/formatDate.ts
@@ -1,0 +1,19 @@
+export const formatDate = (dateString: string) => {
+  const date = new Date(dateString);
+  return (
+    date
+      .toLocaleDateString("ko-KR", {
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      })
+      .replace(/\. /g, ".")
+      .replace(/\.$/, "") +
+    " " +
+    date.toLocaleTimeString("ko-KR", {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    })
+  );
+};

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -1,4 +1,4 @@
 export * from "./cn";
 export * from "./queryClient";
-export * from "./QueryClientProvider";
+export { default as QueryProvider } from "./QueryClientProvider";
 export * from "./formatDate";

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -1,0 +1,4 @@
+export * from "./cn";
+export * from "./queryClient";
+export * from "./QueryClientProvider";
+export * from "./formatDate";

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -5,3 +5,4 @@ export * from "./videoFileMeta";
 export type { ApiResponse } from "./apiResponse";
 export * from "./mypage/bookmark";
 export * from "./mypage/recenthistory";
+export * from "./mypage/myreview";

--- a/src/shared/types/mypage/myreview.ts
+++ b/src/shared/types/mypage/myreview.ts
@@ -1,0 +1,22 @@
+import { PageInfo } from "@/shared/types/pagination";
+
+// 내가 쓴 댓글 형태 안쪽 타입
+export interface MyReview {
+  commentId: number;
+  content: string;
+  contentsPosterUrl: string;
+  writerId: number;
+  writerNickname: string;
+  createdDate: string;
+}
+
+// 내가 쓴 댓글 목록 조회될 때 타입
+export interface MyReviewListResponse {
+  pageInfo: PageInfo;
+  dataList: MyReview[];
+}
+
+// 내 댓글 삭제 요청 보낼 때 (프 -> 백) - 안씀
+export interface MyReviewDeleteRequest {
+  commentId: number;
+}


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 적어주세요

- [x] 마이페이지 내 댓글목록 조회 API 연동
- [x] 마이페이지 내 댓글 삭제 API 연동
- [x] 내 댓글목록 모달창 내부 마진값 수정 + cursor-pointer 효과 추가
- [x] 커스텀 추천 로직 페이지 요소 이름 변경 (숏폼 트렌드 -> 재시청률)

### 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. src에 이미지 url만 등록하면 됩니다. -->

| 구현 내용 |             SE              |  
| :-------: | :-------------------------: | 
|    GIF    | <img src = "https://github.com/user-attachments/assets/9d2f0294-6277-4bc7-80f1-21713e6d2c93" width ="250"> |
|    GIF    | <img src = "https://github.com/user-attachments/assets/0e241aa5-ecf4-4c48-9c05-3517dd833f54" width ="250"> |
|    GIF    | <img src = "https://github.com/user-attachments/assets/fa77e955-d762-42b2-829f-d671a1c7a95b" width ="250"> |
|    GIF    | <img src = "https://github.com/user-attachments/assets/5ae513c2-c1a7-4115-8f57-1a268da46ea6" width ="250"> |
|    GIF    | <img src = "https://github.com/user-attachments/assets/87de8453-f406-48f7-ad1e-37d545f28d16" width ="250"> |


## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->
src\shared\types\mypage\myreview.ts : 내 댓글목록 관련 타입 정리
src\entities\myreview\ : 댓글목록 조회 & 삭제 관련 API 모음


## ☑️ 체크 리스트

> 체크 리스트를 확인해주세요

- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?

## #️⃣ 연관된 이슈

> ex) #87 

## 💬 리뷰 요구사항
> 내 댓글목록 모달창 내부 마진 크기와 cursor-pointer 색 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 내 리뷰가 실제 데이터로 표시되고 무한 페이징(페이지별 로드) 지원
  * 개별 리뷰 삭제 및 삭제 확인 모달 추가
  * 리뷰 항목에 작성자, 작성일시, 포스터 이미지가 실제 값으로 표시되며 날짜 포맷 개선
  * UI 라벨/프리셋에서 "숏폼 트렌드"가 "재시청률"으로 변경
  * 추가 원격 이미지 호스트 지원으로 외부 이미지 로딩 범위 확대
<!-- end of auto-generated comment: release notes by coderabbit.ai -->