### PR TITLE
[OT-205][FEAT]: 마이페이지 대시보드 전체 통계 원그래프 API 연동

### DIFF
--- a/src/entities/dashboard/api/index.ts
+++ b/src/entities/dashboard/api/index.ts
@@ -1,0 +1,1 @@
+export { tagRankingApi } from "./tagRankingApi";

--- a/src/entities/dashboard/api/tagRankingApi.ts
+++ b/src/entities/dashboard/api/tagRankingApi.ts
@@ -1,0 +1,6 @@
+import { api } from "@shared/api";
+import { ApiResponse, TagRankingResponse } from "@shared/types";
+
+export const tagRankingApi = {
+  getTagRankings: async () => await api.get<ApiResponse<TagRankingResponse>>("/tag/me/ranking"),
+};

--- a/src/entities/dashboard/hooks/index.ts
+++ b/src/entities/dashboard/hooks/index.ts
@@ -1,0 +1,1 @@
+import { useTagRanking } from "./useTagRanking";

--- a/src/entities/dashboard/hooks/useTagRanking.ts
+++ b/src/entities/dashboard/hooks/useTagRanking.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { tagRankingApi } from "@entities/dashboard/api";
+
+export function useTagRanking() {
+  return useQuery({
+    queryKey: ["tagRanking"],
+    queryFn: async () => {
+      const res = await tagRankingApi.getTagRankings();
+      return res.data.data;
+    },
+  });
+}

--- a/src/features/dashboard/components/DashboardContentBox.tsx
+++ b/src/features/dashboard/components/DashboardContentBox.tsx
@@ -1,12 +1,56 @@
 "use client";
 
-import { DashboardContentsMockData } from "@shared/mocks/mockDashboardcontent";
 import { DashboardContentList } from "@features/dashboard/components";
+import { useTagRanking } from "@entities/dashboard/hooks/useTagRanking";
+import { DashboardData } from "@shared/types/mypage/dashboard";
+
+const COLORS = ["#9d0037", "#f10059", "#ff768f", "#ffa4b2", "#ffecef"];
 
 export default function DashboardContentBox() {
+  const { data, isLoading, isError } = useTagRanking();
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-100">
+        <p className="text-ot-text">로딩 중 ~</p>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="flex items-center justify-center h-100">
+        <p className="text-ot-gray-600">
+          통계 그래프를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
+        </p>
+      </div>
+    );
+  }
+
+  const chartData: DashboardData = {
+    // labels: data?.rankings.map((tag) => `${tag.tagName}`) ?? [],
+    labels: data?.rankings.map((tag) => (tag.etc ? tag.tagName : `#${tag.tagName}`)) ?? [],
+    datasets: [
+      {
+        label: "시청 통계",
+        data: data?.rankings.map((tag) => tag.count) ?? [],
+        backgroundColor: COLORS,
+        borderColor: COLORS,
+        borderWidth: 0,
+      },
+    ],
+    tagDetails: [],
+  };
+
   return (
     <div className="w-full mx-auto border border-ot-text rounded-lg flex flex-col items-center pt-6 pb-3">
-      <DashboardContentList data={DashboardContentsMockData} />
+      {data?.rankings.length === 0 ? (
+        <div className="flex items-center justify-center h-100">
+          <p className="text-ot-gray-600">시청 기록이 없습니다.</p>
+        </div>
+      ) : (
+        <DashboardContentList data={chartData} />
+      )}
     </div>
   );
 }

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -6,3 +6,4 @@ export type { ApiResponse } from "./apiResponse";
 export * from "./mypage/bookmark";
 export * from "./mypage/recenthistory";
 export * from "./mypage/myreview";
+export * from "./mypage/dashboard";

--- a/src/shared/types/mypage/dashboard.ts
+++ b/src/shared/types/mypage/dashboard.ts
@@ -1,3 +1,15 @@
+export interface TagRanking {
+  tagId: number;
+  tagName: string;
+  count: number;
+  etc: boolean;
+}
+
+export interface TagRankingResponse {
+  rankings: TagRanking[];
+}
+
+// ==================== Mock 데이터 타입 또는 차트 디자인 관련 ====================
 // 태그 상세 통계 모달창 추천 콘텐츠 관련
 export interface RecommendedContent {
   id: number;


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 적어주세요

- [x] 마이페이지 대시보드 전체 통계 원그래프 API 연동


### 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. src에 이미지 url만 등록하면 됩니다. -->

| 구현 내용 |             SE              |           13 mini           |           15 pro            |
| :-------: | :-------------------------: | :-------------------------: | :-------------------------: |
|    GIF    | <img src = "" width ="250"> | <img src = "" width ="250"> | <img src = "" width ="250"> |


https://github.com/user-attachments/assets/af9d4808-77c2-49a9-a017-73c30032f75c


## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

src\shared\types\mypage\dashboard.ts : 대시보드 시청 통계 원그래프 관련 타입 모음
src\entities\dashboard\ : 대시보드 시청 통계 원그래프 관련 API 모음


## ☑️ 체크 리스트

> 체크 리스트를 확인해주세요

- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?

## #️⃣ 연관된 이슈

> ex) #90 

## 💬 리뷰 요구사항

> 시청 통계가 안넘어와서 하나도 없는 걸로 뜹니다. 해당 텍스트 추가해서 영상에서 보입니다.
