### PR TITLE
[OT-204] [FEAT]: Reissue를 통한 Token 재발급 관리

### DIFF
--- a/src/shared/api/apiClient.ts
+++ b/src/shared/api/apiClient.ts
@@ -37,12 +37,6 @@ api.interceptors.response.use(
       return Promise.reject(new Error(message));
     }
 
-    if (originalRequest.url === "/auth/reissue") {
-      console.error("[Reissue API 자체 실패]");
-      isRefreshing = false;
-      return Promise.reject(new Error("인증이 만료되었습니다. 다시 로그인해주세요."));
-    }
-
     // 이미 재시도한 요청이면 에러 반환
     if (originalRequest._retry) {
       return Promise.reject(new Error(message));

--- a/src/shared/api/apiClient.ts
+++ b/src/shared/api/apiClient.ts
@@ -1,6 +1,24 @@
-import axios from "axios";
+import axios, { AxiosResponse, InternalAxiosRequestConfig } from "axios";
+import { reissueApi } from "@shared/api/reissueApi";
 
 const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+interface RetryConfig extends InternalAxiosRequestConfig {
+  _retry?: boolean;
+}
+
+//동시성 제어 변수
+let isRefreshing = false;
+let refreshSubscribers: Array<(error?: Error) => void> = [];
+
+function onRefreshed(error?: Error) {
+  refreshSubscribers.forEach((callback) => callback(error));
+  refreshSubscribers = [];
+}
+
+function addRefreshSubscriber(callback: (error?: Error) => void) {
+  refreshSubscribers.push(callback);
+}
 
 export const api = axios.create({
   baseURL,
@@ -10,29 +28,72 @@ export const api = axios.create({
 });
 
 api.interceptors.response.use(
-  (response) => response,
+  (response: AxiosResponse) => response,
   async (error) => {
-    const originalRequest = error.config;
+    const originalRequest = error.config as RetryConfig;
     const message = error.response?.data?.message || error.message;
 
-    if (error.response?.status === 401 && !originalRequest._retry) {
-      if (originalRequest.url === "/auth/reissue") {
-        console.error("[reissue 실패] 리다이렉트 예정:", message);
-        // window.location.href = "/auth/login"; // TODO: 디버깅 후 주석 해제
-        return Promise.reject(new Error(message));
-      }
-
-      originalRequest._retry = true;
-      try {
-        await api.post("/auth/reissue");
-        return api(originalRequest);
-      } catch {
-        console.error("[reissue catch] 리다이렉트 예정:", message);
-        // window.location.href = "/auth/login"; // TODO: 디버깅 후 주석 해제
-        return Promise.reject(new Error(message));
-      }
+    if (error.response?.status !== 401) {
+      return Promise.reject(new Error(message));
     }
 
-    return Promise.reject(new Error(message));
+    if (originalRequest.url === "/auth/reissue") {
+      console.error("[Reissue API 자체 실패]");
+      isRefreshing = false;
+      return Promise.reject(new Error("인증이 만료되었습니다. 다시 로그인해주세요."));
+    }
+
+    // 이미 재시도한 요청이면 에러 반환
+    if (originalRequest._retry) {
+      return Promise.reject(new Error(message));
+    }
+
+    originalRequest._retry = true;
+
+    if (isRefreshing) {
+      console.log("[대기] 다른 요청이 토큰 갱신 중:", originalRequest.url);
+      return new Promise((resolve, reject) => {
+        addRefreshSubscriber((error) => {
+          if (error) {
+            console.log("[대기 요청 실패]", originalRequest.url);
+            reject(error);
+          } else {
+            console.log("[대기 요청 재시도]", originalRequest.url);
+            api(originalRequest)
+              .then(resolve)
+              .catch(reject);
+          }
+        });
+      });
+    }
+
+    //갱신 시작
+    isRefreshing = true;
+    console.log("[첫 요청이 토큰 갱신 시작]", originalRequest.url);
+
+    try {
+      await reissueApi.refresh();
+      
+      console.log("[토큰 갱신 성공 - 대기 요청들 깨우기]");
+      
+      // 대기 중인 모든 요청들에게 성공 알림
+      onRefreshed();
+
+      console.log("[원래 요청 재시도]", originalRequest.url);
+      return api(originalRequest);
+      
+    } catch (refreshError) {
+      console.error("[토큰 갱신 실패]", refreshError);
+      
+      const error = refreshError instanceof Error
+        ? refreshError
+        : new Error("토큰 갱신 실패");
+      onRefreshed(error);
+
+      return Promise.reject(error);
+      
+    } finally {
+      isRefreshing = false;
+    }
   },
 );

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -1,1 +1,2 @@
 export { api } from "./apiClient";
+export {reissueApi } from "./reissueApi"

--- a/src/shared/api/reissueApi.ts
+++ b/src/shared/api/reissueApi.ts
@@ -1,0 +1,14 @@
+import axios from "axios";
+
+const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+export const reissueApi = {
+  refresh: async (): Promise<void> => {
+    console.log("[Token 갱신 시작]");
+    await axios.post(`${baseURL}auth/reissue`, null, {
+      withCredentials: true,
+      headers: { "Content-Type": "application/json" },
+    });
+    console.log("[Token 갱신 성공]");
+  },
+};


### PR DESCRIPTION
## 📝 작업 내용

> reissue API를 통한 accessToken 재생성 관리

- [x] reissue API 생성
- [x] reissue Test

### 📷 스크린샷

| 구현 내용 |             reissue Token관리            |  
| :-------: | :-------------------------: |
|    GIF    | <img src = "https://github.com/user-attachments/assets/3c10745b-bb41-4997-9380-c3a96fadb0e6" width ="1400"> | 

- 위의 이미지를 보시면 accessToken이 만료되어 '401' 에러가 난것을 확인할 수 있습니다.
- 에러가 나면 순차적으로 /reissue를 통해 accessToken이 재발급되고 에러났던 API들을 순차적으로 재실행합니다. 

## 🖥️ 주요 코드 설명

`apiClient`

- 사용자가 페이지 진입 시 3개 API 동시 호출을 가정하고, 동시성제어가 없다면
- API 1,2,3이 동시 전송됨(모두 토큰 만료) -> 동시에 reissue호출로 중복발생 -> 총 3번의 API호출발생 (서버 부하 3배)
- API 1: 401 감지
    → `isRefreshing` = false 확인
    → `isRefreshing` = true 설정
    → /auth/reissue 호출 시작 
  
  - API 2: 401 감지
    → isRefreshing = true 확인 
    → 대기 큐에 추가 (`refreshSubscribers`)
  
  - API 3: 401 감지
    → isRefreshing = true 확인 
    → 대기 큐에 추가 (`refreshSubscribers`)
- 결국 API 1번실행으로 서버 부하 최소화
- 저희 프로젝트의 경우 한 화면에서 많게는 5,6번의 API호출이 동시다발적으로 발생하는 점을 고려하여 동시성 제어를 추가하였습니다.

```ts
let isRefreshing = false;
let refreshSubscribers: Array<(error?: Error) => void> = [];

function onRefreshed(error?: Error) {
  refreshSubscribers.forEach((callback) => callback(error));
  refreshSubscribers = [];
}

function addRefreshSubscriber(callback: (error?: Error) => void) {
  refreshSubscribers.push(callback);
}
```

## ☑️ 체크 리스트
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?

## #️⃣ 연관된 이슈

> ex) #89 

## 💬 리뷰 요구사항

> accessToken이 만료되고 refresh하는 과정이 이해가 안가시면 말씀해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 토큰 재발급용 공개 API 추가로 토큰 갱신 호출을 분리 제공
* **버그 수정**
  * 동시 다중 요청 시 토큰 갱신 동기화 개선으로 중복 갱신 및 실패 상황 완화
  * 401 처리 및 재시도 흐름 강화로 세션 만료 복구 신뢰성 향상
  * 비-401 오류 응답 처리 정상화 및 요청 타임아웃/자격증명 설정 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->