### PR TITLE
[OT-251] [FIX]: 관심사 태그 갯수에 따른 플레이리스트 렌더링 이슈 해결

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@ import {
   MainCarousel,
   TrendingCarousel,
   RecommendCarousel,
-  RecommendTagsCarousel,
+  RecommendTagsSection,
   HistoryCarousel
 } from "@entities/home/components";
 
@@ -15,9 +15,7 @@ export default function Home() {
       <TrendingCarousel />
       <RecommendCarousel />
       <HistoryCarousel/>
-      <RecommendTagsCarousel index={0} />
-      <RecommendTagsCarousel index={1} />
-      <RecommendTagsCarousel index={2} />
+      <RecommendTagsSection />
       <Footer />
     </div>
   );

--- a/src/entities/home/components/RecommendTagsSection.tsx
+++ b/src/entities/home/components/RecommendTagsSection.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useMemberProfile } from "@entities/profile/hooks";
+import RecommendTagsCarousel from "./RecommendTagsCarousel";
+
+export default function RecommendTagsSection() {
+  const { data: profile } = useMemberProfile();
+  const tagCount = profile?.preferredTags?.length ?? 0;
+
+  return (
+    <>
+      {Array.from({ length: tagCount }, (_, i) => (
+        <RecommendTagsCarousel key={i} index={i} />
+      ))}
+    </>
+  );
+}

--- a/src/entities/home/components/index.ts
+++ b/src/entities/home/components/index.ts
@@ -3,4 +3,5 @@ export { default as ContentCarousel } from './ContentCarousel';
 export { default as TrendingCarousel } from './TrendingCarousel';
 export { default as RecommendCarousel } from "./RecommendCarousel";
 export { default as RecommendTagsCarousel } from "./RecommendTagsCarousel";
+export { default as RecommendTagsSection } from "./RecommendTagsSection";
 export { default as HistoryCarousel } from "./HistoryCarousel";


### PR DESCRIPTION
## 📝 작업 내용

> 온보딩에서 관심사 태그 선택 갯수에 따라 플레이리스트가 변해야하는데 고정이었던 이슈를 해결했습니다.

- [x] 이슈 해결

### 📷 스크린샷

| 구현 내용 |             관심사 태그 설정              |
| :-------: | :-------------------------: |
|    GIF    | <img src = "https://github.com/user-attachments/assets/8def7a71-ded3-4cea-a6f0-f3526a47205a" width ="1200"> | 


| 구현 내용 |             홈 플레이리스트              |
| :-------: | :-------------------------: |
|    GIF    | <img src = "https://github.com/user-attachments/assets/c1cf38c3-5a6f-444e-abdc-f1d7d60e7351" width ="1200"> | 

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

`RecommendTagSection.tsx`

- 사용자 프로필 정보를 가져오는 `useMemberProfile()`를 통해 tag를 가져옵니다.
<img width="258" height="312" alt="image" src="https://github.com/user-attachments/assets/a7e72d9c-e406-4ba8-8e06-385748166323" />

- preferredTags의 length(배열길이)를 파악하여 tagCount 값으로 저장합니다.
- 콜백으로 i값을 넘기면서
```ts
<RecommendTagsCarousel key={0} index={0} /> 
  <RecommendTagsCarousel key={1} index={1} /> 
  <RecommendTagsCarousel key={2} index={2} /> 
```

- 위의 코드처럼 RecommendTagSection에 들어갑니다.

```ts
"use client";

import { useMemberProfile } from "@entities/profile/hooks";
import RecommendTagsCarousel from "./RecommendTagsCarousel";

export default function RecommendTagsSection() {
  const { data: profile } = useMemberProfile();
  const tagCount = profile?.preferredTags?.length ?? 0;

  return (
    <>
      {Array.from({ length: tagCount }, (_, i) => (
        <RecommendTagsCarousel key={i} index={i} />
      ))}
    </>
  );
}
```

## ☑️ 체크 리스트

> 체크 리스트를 확인해주세요

- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?

## #️⃣ 연관된 이슈

> ex) #106 

## 💬 리뷰 요구사항

> 없습니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **개선 사항**
  * 추천 태그 섹션이 개선되어 사용자의 선호 태그 수에 따라 동적으로 생성되고 표시됩니다. 개인화된 추천 경험이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->