### PR TITLE
[OT-266] [FEAT]: 마이페이지 - 북마크, 시청내역, 내 댓글목록 무한스크롤 추가

### DIFF
--- a/src/entities/bookmark/hooks/useBookmarkContents.ts
+++ b/src/entities/bookmark/hooks/useBookmarkContents.ts
@@ -1,11 +1,11 @@
-import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
-import { bookmarkApi } from "@entities/bookmark/api";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { bookmarkApi, BookmarkContentItem } from "@entities/bookmark/api";
 
 export function useBookmarkContents() {
-  return useInfiniteQuery({
+  const query = useInfiniteQuery({
     queryKey: ["bookmarkContents"],
     queryFn: async ({ pageParam = 0 }) => {
-      const res = await bookmarkApi.getBookmarkContents(pageParam);
+      const res = await bookmarkApi.getBookmarkContents(pageParam as number);
       return res.data.data;
     },
     initialPageParam: 0,
@@ -14,4 +14,9 @@ export function useBookmarkContents() {
       return currentPage + 1 < totalPage ? currentPage + 1 : undefined;
     },
   });
+
+  const bookmarkContents: BookmarkContentItem[] =
+    query.data?.pages.flatMap((page) => page.dataList) ?? [];
+
+  return { ...query, bookmarkContents };
 }

--- a/src/entities/bookmark/hooks/useBookmarkShortForms.ts
+++ b/src/entities/bookmark/hooks/useBookmarkShortForms.ts
@@ -1,11 +1,11 @@
-import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
-import { bookmarkApi } from "@entities/bookmark/api";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { bookmarkApi, BookmarkShortFormItem } from "@entities/bookmark/api";
 
 export function useBookmarkShortForms() {
-  return useInfiniteQuery({
+  const query = useInfiniteQuery({
     queryKey: ["bookmarkShortForms"],
     queryFn: async ({ pageParam = 0 }) => {
-      const res = await bookmarkApi.getBookmarkShortForms(pageParam);
+      const res = await bookmarkApi.getBookmarkShortForms(pageParam as number);
       return res.data.data;
     },
     initialPageParam: 0,
@@ -14,4 +14,9 @@ export function useBookmarkShortForms() {
       return currentPage + 1 < totalPage ? currentPage + 1 : undefined;
     },
   });
+
+  const bookmarkShortForms: BookmarkShortFormItem[] =
+    query.data?.pages.flatMap((page) => page.dataList) ?? [];
+
+  return { ...query, bookmarkShortForms };
 }

--- a/src/entities/myreview/hooks/useMyreviews.ts
+++ b/src/entities/myreview/hooks/useMyreviews.ts
@@ -1,11 +1,11 @@
-import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
-import { myreviewApi } from "@entities/myreview/api";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { myreviewApi, MyReview } from "@entities/myreview/api";
 
 export function useMyreviews() {
-  return useInfiniteQuery({
+  const query = useInfiniteQuery({
     queryKey: ["myreviews"],
     queryFn: async ({ pageParam = 0 }) => {
-      const res = await myreviewApi.getMyReviews(pageParam);
+      const res = await myreviewApi.getMyReviews(pageParam as number);
       return res.data.data;
     },
     initialPageParam: 0,
@@ -14,4 +14,8 @@ export function useMyreviews() {
       return currentPage + 1 < totalPage ? currentPage + 1 : undefined;
     },
   });
+
+  const myreviews: MyReview[] = query.data?.pages.flatMap((page) => page.dataList) ?? [];
+
+  return {...query, myreviews}
 }

--- a/src/entities/recenthistory/hooks/useRecentHistory.ts
+++ b/src/entities/recenthistory/hooks/useRecentHistory.ts
@@ -1,11 +1,12 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { recentHistoryApi } from "@entities/recenthistory/api";
+import { PlaylistItem } from "@shared/types";
 
 export function useRecentHistory() {
-  return useInfiniteQuery({
+  const query = useInfiniteQuery({
     queryKey: ["recentHistory"],
     queryFn: async ({ pageParam = 0 }) => {
-      const res = await recentHistoryApi.getRecentHistorys(pageParam);
+      const res = await recentHistoryApi.getRecentHistorys(pageParam as number);
       return res.data.data;
     },
     initialPageParam: 0,
@@ -14,4 +15,9 @@ export function useRecentHistory() {
       return currentPage + 1 < totalPage ? currentPage + 1 : undefined;
     },
   });
+  
+  const recentHistoryList: PlaylistItem[] =
+    query.data?.pages.flatMap((page) => page.dataList) ?? [];
+
+  return { ...query, recentHistoryList };
 }

--- a/src/entities/review/api/review.ts
+++ b/src/entities/review/api/review.ts
@@ -68,7 +68,7 @@ export interface EditReviewRequest {
   isSpoiler: boolean;
 }
 
-export interface EditReviewResponse extends WriteReviewResponse {}
+export type EditReviewResponse = WriteReviewResponse;
 
 export const editReview = async (
   commentId: number,

--- a/src/features/bookmark/components/BookmarkContentList.tsx
+++ b/src/features/bookmark/components/BookmarkContentList.tsx
@@ -3,21 +3,28 @@
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import { Play, X } from "lucide-react";
+import { Play, X, Loader2 } from "lucide-react";
 import { ConfirmModal } from "@base-components";
 import { useBookmarkContents } from "@entities/bookmark/hooks";
 import { useToggleBookmark } from "@entities/bookmark/hooks";
 import { useMediaLink } from "@/shared/hooks";
+import { useInfiniteScroll } from "@/shared/hooks";
 
 export default function BookmarkContentList() {
   const [isDeleteContentModalOpen, setIsDeleteContentModalOpen] =
     useState<boolean>(false);
   const [selectedMediaId, setSelectedMediaId] = useState<number | null>(null);
 
-  const { data, isLoading, isError } = useBookmarkContents();
+  const { bookmarkContents, isLoading, isError, hasNextPage, isFetchingNextPage, fetchNextPage } = useBookmarkContents();
   const { mutate: deleteBookmark, isPending } = useToggleBookmark();
   const { getMediaHref } = useMediaLink();
   const router = useRouter();
+
+  const { observerRef } = useInfiniteScroll({
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  });
 
   const handleDelete = () => {
     if (isPending || selectedMediaId === null) return;
@@ -28,8 +35,6 @@ export default function BookmarkContentList() {
       },
     });
   };
-
-  const items = data?.pages.flatMap((page) => page.dataList) ?? [];
 
   if (isLoading) {
     return (
@@ -49,7 +54,7 @@ export default function BookmarkContentList() {
     );
   }
 
-  if (items.length === 0) {
+  if (bookmarkContents.length === 0) {
     return (
       <div className="flex h-100 items-center justify-center">
         <p className="text-ot-gray-600">현재 북마크한 콘텐츠가 없습니다.</p>
@@ -60,7 +65,7 @@ export default function BookmarkContentList() {
   return (
     <div className="no-scrollbar h-100 w-full overflow-y-auto">
       <div className="relative grid grid-cols-2 gap-x-10 gap-y-2">
-        {items.map((item) => (
+        {bookmarkContents.map((item) => (
           <div
             key={item.mediaId}
             onClick={() =>
@@ -122,6 +127,13 @@ export default function BookmarkContentList() {
             </button>
           </div>
         ))}
+      </div>
+
+      {/* 무한스크롤 감지 영역 */}
+      <div ref={observerRef} className="flex h-4 justify-center">
+        {isFetchingNextPage && (
+          <Loader2 className="text-ot-placeholder mt-4 animate-spin" size={20} />
+        )}
       </div>
 
       <ConfirmModal

--- a/src/features/bookmark/components/BookmarkShortsList.tsx
+++ b/src/features/bookmark/components/BookmarkShortsList.tsx
@@ -2,18 +2,25 @@
 
 import Image from "next/image";
 import { useState } from "react";
-import { Play, X } from "lucide-react";
+import { Play, X, Loader2 } from "lucide-react";
 import { ConfirmModal } from "@base-components";
 import { useBookmarkShortForms } from "@entities/bookmark/hooks";
 import { useToggleBookmark } from "@entities/bookmark/hooks";
+import { useInfiniteScroll } from "@/shared/hooks";
 
 export default function BookmarkShortsList() {
   const [isDeleteShortsModalOpen, setIsDeleteShortsModalOpen] =
     useState<boolean>(false);
   const [selectedMediaId, setSelectedMediaId] = useState<number | null>(null);
 
-  const { data, isLoading } = useBookmarkShortForms();
+  const { bookmarkShortForms, isLoading, isError, hasNextPage, isFetchingNextPage, fetchNextPage } = useBookmarkShortForms();
   const { mutate: deleteBookmark, isPending } = useToggleBookmark();
+
+  const { observerRef } = useInfiniteScroll({
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  });
 
   const handleDelete = () => {
     if (selectedMediaId === null) return;
@@ -21,8 +28,6 @@ export default function BookmarkShortsList() {
       onSuccess: () => setIsDeleteShortsModalOpen(false),
     });
   };
-
-  const items = data?.pages.flatMap((page) => page.dataList) ?? [];
 
   if (isLoading) {
     return (
@@ -32,7 +37,17 @@ export default function BookmarkShortsList() {
     );
   }
 
-  if (items.length === 0) {
+  if (isError) {
+    return (
+      <div className="flex h-100 items-center justify-center">
+        <p className="text-ot-gray-600">
+          북마크를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
+        </p>
+      </div>
+    );
+  }
+
+  if (bookmarkShortForms.length === 0) {
     return (
       <div className="flex h-[50vh] items-center justify-center">
         <p className="text-ot-gray-600">현재 북마크한 숏폼이 없습니다.</p>
@@ -43,7 +58,7 @@ export default function BookmarkShortsList() {
   return (
     <div className="no-scrollbar h-[50vh] w-full overflow-y-auto">
       <div className="relative grid grid-cols-2 gap-x-10 gap-y-2">
-        {items.map((item) => (
+        {bookmarkShortForms.map((item) => (
           <div
             key={item.mediaId}
             className="group hover:bg-ot-gray-900 relative flex w-full cursor-pointer items-center gap-8 rounded-xl p-4 transition-all duration-200"
@@ -99,11 +114,23 @@ export default function BookmarkShortsList() {
           </div>
         ))}
       </div>
+
+      {/* 무한스크롤 감지 영역 */}
+      <div ref={observerRef} className="flex h-4 justify-center">
+        {isFetchingNextPage && (
+          <Loader2 className="text-ot-placeholder mt-4 animate-spin" size={20} />
+        )}
+      </div>
+
       <ConfirmModal
         isOpen={isDeleteShortsModalOpen}
         message="북마크를 삭제하시겠습니까?"
         onConfirm={handleDelete}
-        onClose={() => setIsDeleteShortsModalOpen(false)}
+        onClose={() => {
+          if (isPending) return;
+          setIsDeleteShortsModalOpen(false);
+          setSelectedMediaId(null);
+        }}
         confirmText="네, 삭제합니다"
         cancelText="남겨두기"
         disabled={isPending}

--- a/src/features/mypage/components/MyReviewModal.tsx
+++ b/src/features/mypage/components/MyReviewModal.tsx
@@ -8,6 +8,7 @@ import { ConfirmModal } from "@base-components";
 import { useMyreviews } from "@entities/myreview/hooks";
 import { useDeleteMyreview } from "@entities/myreview/hooks";
 import { useOutsideClick } from "@shared/hooks";
+import { useInfiniteScroll } from "@shared/hooks";
 import { formatDate } from "@shared/lib";
 
 interface MyReviewModalProps {
@@ -18,10 +19,12 @@ interface MyReviewModalProps {
 export default function MyReviewModal({ isOpen, onClose }: MyReviewModalProps) {
   // Mock 데이터 아직 리뷰 숫자만 있으니까 number, 아니면 string으로 나중에 바꾸기
   const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
-  const [isMounted, setIsMounted] = useState<boolean>(false);
   const modalRef = useRef<HTMLDivElement>(null);
   const deleteTargetIdRef = useRef<number | null>(null);
-  deleteTargetIdRef.current = deleteTargetId; // 항상 최신 값 동기화
+
+  useEffect(() => {
+    deleteTargetIdRef.current = deleteTargetId;
+  }, [deleteTargetId]);
 
   const { data, isLoading, isError } = useMyreviews();
   const { mutate: deleteComment, isPending } = useDeleteMyreview();
@@ -31,7 +34,6 @@ export default function MyReviewModal({ isOpen, onClose }: MyReviewModalProps) {
   useOutsideClick(modalRef, onClose, isOpen && deleteTargetId === null); // 관련 hook 추가하여 사용
 
   useEffect(() => {
-    setIsMounted(true);
     if (isOpen) {
       document.body.style.overflow = "hidden"; // 모달창 열리면 뒷 원본 페이지 스크롤 기능 X
       const handleEsc = (e: KeyboardEvent) => {
@@ -51,7 +53,7 @@ export default function MyReviewModal({ isOpen, onClose }: MyReviewModalProps) {
     }
   }, [isOpen, onClose]);
 
-  if (!isOpen || !isMounted) {
+  if (typeof window === "undefined" || !isOpen) {
     return null;
   }
 

--- a/src/features/mypage/components/MyReviewModal.tsx
+++ b/src/features/mypage/components/MyReviewModal.tsx
@@ -86,7 +86,7 @@ export default function MyReviewModal({ isOpen, onClose }: MyReviewModalProps) {
     <div className="fixed inset-0 z-9999 flex items-center justify-center bg-black/50">
       <div
         ref={modalRef}
-        className="bg-ot-gray-800 relative flex max-h-[85vh] w-200 flex-col overflow-hidden rounded-xl shadow-2xl shadow-black/50"
+        className="bg-ot-gray-900 relative flex max-h-[85vh] w-200 flex-col overflow-hidden rounded-xl shadow-2xl shadow-black/50"
         onClick={(e) => e.stopPropagation()}
       >
         <button
@@ -116,7 +116,7 @@ export default function MyReviewModal({ isOpen, onClose }: MyReviewModalProps) {
               {myreviews.map((review) => (
                 <div
                   key={review.commentId}
-                  className="group hover:bg-ot-gray-700 relative flex w-full shrink-0 cursor-pointer items-center gap-5 rounded-xl p-4 transition-all duration-200"
+                  className="group hover:bg-ot-gray-800 relative flex w-full shrink-0 cursor-pointer items-center gap-5 rounded-xl p-4 transition-all duration-200"
                 >
                   {/* 왼쪽 댓글단 작품 이미지 (16 : 9) */}
                   <div className="relative aspect-video w-45 shrink-0 overflow-hidden rounded bg-black">

--- a/src/features/mypage/components/MyReviewModal.tsx
+++ b/src/features/mypage/components/MyReviewModal.tsx
@@ -3,12 +3,12 @@
 import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { X } from "lucide-react";
+import { X, Loader2 } from "lucide-react";
 import { ConfirmModal } from "@base-components";
 import { useMyreviews } from "@entities/myreview/hooks";
 import { useDeleteMyreview } from "@entities/myreview/hooks";
 import { useOutsideClick } from "@shared/hooks";
-import { useInfiniteScroll } from "@shared/hooks";
+import { useInfiniteScrollInModal } from "@features/mypage/components"
 import { formatDate } from "@shared/lib";
 
 interface MyReviewModalProps {
@@ -21,15 +21,22 @@ export default function MyReviewModal({ isOpen, onClose }: MyReviewModalProps) {
   const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
   const modalRef = useRef<HTMLDivElement>(null);
   const deleteTargetIdRef = useRef<number | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null); // 모달 스크롤 영역 인식 관련
 
   useEffect(() => {
     deleteTargetIdRef.current = deleteTargetId;
   }, [deleteTargetId]);
 
-  const { data, isLoading, isError } = useMyreviews();
+  const { myreviews, isLoading, isError, hasNextPage, isFetchingNextPage, fetchNextPage } = useMyreviews();
   const { mutate: deleteComment, isPending } = useDeleteMyreview();
 
-  const reviews = data?.pages.flatMap((page) => page.dataList) ?? [];
+  const { observerRef } = useInfiniteScrollInModal({
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+    scrollContainerRef: scrollRef,
+    isOpen, // 모달 여닫힘 인식
+  });
 
   useOutsideClick(modalRef, onClose, isOpen && deleteTargetId === null); // 관련 hook 추가하여 사용
 
@@ -89,7 +96,7 @@ export default function MyReviewModal({ isOpen, onClose }: MyReviewModalProps) {
           <X size={24} strokeWidth={2} />
         </button>
 
-        <div className="no-scrollbar mx-15 mt-15 mb-10 flex-1 overflow-y-auto">
+        <div ref={scrollRef} className="no-scrollbar mx-15 mt-15 mb-10 flex-1 overflow-y-auto">
           {isLoading ? (
             <div className="flex h-full items-center justify-center">
               <p className="text-ot-text">로딩 중...</p>
@@ -100,13 +107,13 @@ export default function MyReviewModal({ isOpen, onClose }: MyReviewModalProps) {
                 댓글을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
               </p>
             </div>
-          ) : reviews.length === 0 ? (
+          ) : myreviews.length === 0 ? (
             <div className="flex items-center justify-center">
               <p className="text-ot-gray-600">작성한 댓글이 없습니다.</p>
             </div>
           ) : (
             <div className="flex flex-col gap-3">
-              {reviews.map((review) => (
+              {myreviews.map((review) => (
                 <div
                   key={review.commentId}
                   className="group hover:bg-ot-gray-700 relative flex w-full shrink-0 cursor-pointer items-center gap-5 rounded-xl p-4 transition-all duration-200"
@@ -147,8 +154,14 @@ export default function MyReviewModal({ isOpen, onClose }: MyReviewModalProps) {
               ))}
             </div>
           )}
+          <div ref={observerRef} className="flex h-4 justify-center">
+            {isFetchingNextPage && (
+              <Loader2 className="text-ot-placeholder mt-4 animate-spin" size={20} />
+            )}
+          </div>
         </div>
       </div>
+
       <ConfirmModal
         isOpen={deleteTargetId !== null}
         message="댓글을 삭제하시겠습니까?"

--- a/src/features/mypage/components/index.ts
+++ b/src/features/mypage/components/index.ts
@@ -3,3 +3,4 @@ export { default as MyReviewModal } from './MyReviewModal';
 export { default as ProfileInfo } from './ProfileInfo';
 export { default as TabBar } from './TabBar';
 export { default as UserMenuButtons } from './UserMenuButtons';
+export { useInfiniteScrollInModal } from "./useInfiniteScrollInModal"

--- a/src/features/mypage/components/useInfiniteScrollInModal.ts
+++ b/src/features/mypage/components/useInfiniteScrollInModal.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+interface UseInfiniteScrollInModalOptions {
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  fetchNextPage: () => void;
+  threshold?: number;
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>;  // useRef로 사용
+  isOpen: boolean; // 추가
+}
+
+export const useInfiniteScrollInModal = ({
+  hasNextPage,
+  isFetchingNextPage,
+  fetchNextPage,
+  threshold = 0.1,
+  scrollContainerRef,  // 모달의 스크롤 영역 인식 (scrollRef 인식 -> 모달 인식)
+  isOpen,
+}: UseInfiniteScrollInModalOptions) => {
+  const observerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = observerRef.current;
+    if (!el) return;
+    if (!scrollContainerRef.current) return;  // 모달 안켜졌으면 하지 말기
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      },
+      {
+        threshold,
+        root: scrollContainerRef.current,  // scrollRef 위치부터 하기
+      }
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage, threshold, scrollContainerRef, isOpen]);
+
+  return { observerRef };
+};

--- a/src/features/recent-history/components/RecentContentBox.tsx
+++ b/src/features/recent-history/components/RecentContentBox.tsx
@@ -4,9 +4,7 @@ import { RecentContentList } from "@features/recent-history/components";
 import { useRecentHistory } from "@/entities/recenthistory/hooks";
 
 export default function RecentContentBox() {
-  const { data, isLoading, isError } = useRecentHistory();
-
-  const items = data?.pages.flatMap((page) => page.dataList) ?? [];
+  const { recentHistoryList, isLoading, isError, hasNextPage, isFetchingNextPage, fetchNextPage } = useRecentHistory();
 
   if (isLoading) {
     return (
@@ -29,7 +27,12 @@ export default function RecentContentBox() {
   return (
     <div className="flex w-full flex-col">
       <div>
-        <RecentContentList items={items} />
+        <RecentContentList
+          items={recentHistoryList}
+          hasNextPage={hasNextPage}
+          isFetchingNextPage={isFetchingNextPage}
+          fetchNextPage={fetchNextPage}
+        />
       </div>
     </div>
   );

--- a/src/features/recent-history/components/RecentContentList.tsx
+++ b/src/features/recent-history/components/RecentContentList.tsx
@@ -2,24 +2,40 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { Loader2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ScrollEdgeButton } from "@base-components";
 import { PlaylistItem } from "@shared/types";
 import { useMediaLink } from "@/shared/hooks";
+import { useInfiniteScroll } from "@shared/hooks";
 
 interface RecentContentListProps {
   items: PlaylistItem[];
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  fetchNextPage: () => void;
 }
 
-export default function RecentContentList({ items }: RecentContentListProps) {
-  const scrollRef = useRef<HTMLDivElement>(null);
+export default function RecentContentList({
+  items,
+  hasNextPage,
+  isFetchingNextPage,
+  fetchNextPage,
+}: RecentContentListProps) {
+  const horizontalRef = useRef<HTMLDivElement>(null);
   const [showRightButton, setShowRightButton] = useState<boolean>(true); // 오른쪽 버튼 상태 (처음은 있음)
   const [showLeftButton, setShowLeftButton] = useState<boolean>(false); // 왼쪽 버튼 상태 (처음엔 없음)
   const { getMediaHref } = useMediaLink();
 
+  const { observerRef } = useInfiniteScroll({
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  });
+
   const checkScrollPosition = () => {
-    if (scrollRef.current) {
-      const { scrollLeft, scrollWidth, clientWidth } = scrollRef.current;
+    if (horizontalRef.current) {
+      const { scrollLeft, scrollWidth, clientWidth } = horizontalRef.current;
 
       // 현재 위치가 오른쪽 끝인지 확인 -> 맞으면 오른쪽 화살표 지움
       const isEnd = scrollLeft + clientWidth >= scrollWidth - 5;
@@ -33,7 +49,7 @@ export default function RecentContentList({ items }: RecentContentListProps) {
 
   // 가로 휠 스크롤 기능
   useEffect(() => {
-    const el = scrollRef.current;
+    const el = horizontalRef.current;
     if (!el) {
       return;
     }
@@ -62,9 +78,9 @@ export default function RecentContentList({ items }: RecentContentListProps) {
 
   // 오른쪽 끝으로 한 번에 스크롤
   const scrollToRight = () => {
-    if (scrollRef.current) {
-      scrollRef.current.scrollTo({
-        left: scrollRef.current.scrollWidth,
+    if (horizontalRef.current) {
+      horizontalRef.current.scrollTo({
+        left: horizontalRef.current.scrollWidth,
         behavior: "smooth",
       });
       setTimeout(checkScrollPosition, 500);
@@ -73,8 +89,8 @@ export default function RecentContentList({ items }: RecentContentListProps) {
 
   // 왼쪽 끝으로 한 번에 스크롤
   const scrollToLeft = () => {
-    if (scrollRef.current) {
-      scrollRef.current.scrollTo({
+    if (horizontalRef.current) {
+      horizontalRef.current.scrollTo({
         left: 0,
         behavior: "smooth",
       });
@@ -94,7 +110,7 @@ export default function RecentContentList({ items }: RecentContentListProps) {
     <div className="relative w-full">
       {/* 가로 스크롤 */}
       <div
-        ref={scrollRef}
+        ref={horizontalRef}
         className="no-scrollbar flex gap-6 overflow-x-auto py-8"
       >
         {items.map((item) => (
@@ -105,7 +121,7 @@ export default function RecentContentList({ items }: RecentContentListProps) {
             })}
             className="block"
           >
-            <div key={item.mediaId} className="shrink-0">
+            <div className="shrink-0">
               {/* 포스터 이미지 영역 (이미지 4 : 3 비율) */}
               <div className="bg-ot-gray-800 relative flex aspect-4/3 w-60 items-center justify-center overflow-hidden rounded-lg">
                 {item.thumbnailUrl ? (
@@ -126,6 +142,13 @@ export default function RecentContentList({ items }: RecentContentListProps) {
             </div>
           </Link>
         ))}
+
+        {/* 무한스크롤 감지 영역 */}
+        <div ref={observerRef} className="flex w-4 shrink-0 items-center justify-center">
+          {isFetchingNextPage && (
+            <Loader2 className="text-ot-placeholder animate-spin" size={20} />
+          )}
+        </div>
       </div>
 
       {/* 왼쪽 끝에 스크롤 버튼 */}


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 적어주세요

- [x] 마이페이지 최근 시청내역 무한스크롤 추가
- [x] 마이페이지 북마크 (콘텐츠 | 숏폼) 무한스크롤 추가
- [x] 마이페이지 내 댓글목록 모달창 무한스크롤 추가


### 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. src에 이미지 url만 등록하면 됩니다. -->

| 구현 내용 |             SE              |           13 mini           |           15 pro            |
| :-------: | :-------------------------: | :-------------------------: | :-------------------------: |
|    GIF    | <img src = "" width ="250"> | <img src = "" width ="250"> | <img src = "" width ="250"> |

최근 시청내역 무한스크롤 추가

https://github.com/user-attachments/assets/b0b4cb46-bdee-4a9d-a760-fa4ecab76e36


북마크 콘텐츠 무한스크롤 추가

https://github.com/user-attachments/assets/49660ba4-2421-42c9-b48a-45f1481b85c5


북마크 숏폼 무한스크롤 추가

https://github.com/user-attachments/assets/a0b4f089-a95e-4dd9-bbff-6718a196d232


내 댓글목록 무한스크롤 추가

https://github.com/user-attachments/assets/07ecc9cb-4dd6-4359-a9da-0142fc45f609


## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

src\features\mypage\components\useInfiniteScrollInModal.ts : 내 댓글목록 모달창 전용 무한스크롤
- useRef 사용
- scrollContainerRef: scrollRef 로 스크롤 영역 인식


## ☑️ 체크 리스트

> 체크 리스트를 확인해주세요

- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?

## #️⃣ 연관된 이슈

> ex) #110 

## 💬 리뷰 요구사항

> 내 댓글목록 모달창의 무한스크롤 기능은 useRef를 사용하여 useInfiniteScrollInModal.ts을 따로 만들고 구현하였습니다. 해당 기능으로 모달창 내부 댓글목록 영역을 인식하여 하게 했습니다. (없으면 뷰포트 기준이라 스크롤 기능 작동 X)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 북마크, 숏폼, 내 리뷰, 최근 이력에 무한 스크롤 지원 추가
  * 모달 내부에서도 무한 스크롤 동작 지원

* **UX 개선**
  * 추가 페이지 로드 시 하단 로더 표시로 로딩 상태 명확화
  * 항목이 없을 때의 빈 상태 및 오류 UI 개선
  * 삭제 처리 중 모달 닫기 방지로 작업 안정성 향상

* **Refactor**
  * 데이터 집계 방식 정리로 렌더링 일관성 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->