### PR TITLE
[OT-273] [FEAT]: 검색 API 연동 + 무한스크롤 구현

### DIFF
--- a/src/entities/search/api/getSearchApi.ts
+++ b/src/entities/search/api/getSearchApi.ts
@@ -1,0 +1,24 @@
+import { api } from "@shared/api";
+import {
+  ApiResponse,
+  BasePaginationParams,
+  MediaType,
+  PageInfo,
+} from "@shared/types";
+
+export interface SearchItem {
+  mediaType: MediaType;
+  mediaId: number;
+  title: string;
+  posterUrl: string;
+}
+
+export interface SearchResponse {
+  pageInfo: PageInfo;
+  dataList: SearchItem[];
+}
+
+export const searchApi = async (params: BasePaginationParams) => {
+  const res = await api.get<ApiResponse<SearchResponse>>("/search", { params });
+  return res.data.data;
+};

--- a/src/entities/search/api/index.ts
+++ b/src/entities/search/api/index.ts
@@ -1,1 +1,3 @@
 export { searchPlaylistApi } from "./getSearchPlaylistApi";
+export { searchApi } from "./getSearchApi";
+export type { SearchItem } from "./getSearchApi";

--- a/src/entities/search/components/SearchInput.tsx
+++ b/src/entities/search/components/SearchInput.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { Input } from "@base-components";
-import { Search, X } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { Search, X } from "lucide-react";
+import { Input } from "@base-components";
 
 interface SearchInputProps {
   keyword?: string;
@@ -14,6 +14,10 @@ export default function SearchInput({ keyword }: SearchInputProps) {
   const [inputValue, setInputValue] = useState<string>(keyword ?? "");
 
   const submitSearch = (value: string) => {
+    if (value.length < 2) {
+      alert("검색어는 2글자 이상 입력해주세요.");
+      return;
+    }
     if (value) {
       router.push(`?keyword=${encodeURIComponent(value)}`);
     } else {
@@ -22,7 +26,7 @@ export default function SearchInput({ keyword }: SearchInputProps) {
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
+    if (e.key === "Enter" && !e.nativeEvent.isComposing) {
       submitSearch(inputValue.trim());
     }
   };
@@ -36,7 +40,7 @@ export default function SearchInput({ keyword }: SearchInputProps) {
     <div className="mx-auto flex w-full max-w-160 items-center gap-4">
       <div className="relative flex-1">
         <Input
-          placeholder="콘텐츠를 입력하세요"
+          placeholder="콘텐츠(시리즈) 제목을 입력하세요."
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
           onKeyDown={handleKeyDown}
@@ -45,7 +49,7 @@ export default function SearchInput({ keyword }: SearchInputProps) {
           <button
             type="button"
             onClick={handleClear}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-ot-gray-500 hover:text-ot-gray-600 cursor-pointer"
+            className="text-ot-gray-500 hover:text-ot-gray-600 absolute top-1/2 right-3 -translate-y-1/2 cursor-pointer"
           >
             <X size={18} />
           </button>

--- a/src/entities/search/components/SearchResult.tsx
+++ b/src/entities/search/components/SearchResult.tsx
@@ -1,106 +1,86 @@
 "use client";
 
-import { SearchTip } from "@entities/search/components";
 import Image from "next/image";
 import Link from "next/link";
-
-const MOCK_CONTENTS = [
-  {
-    id: 1,
-    title: "다만 악에서 구하소서",
-    thumbnailVertical: "/images/recommendcontent_img.png",
-  },
-  {
-    id: 2,
-    title: "다만 악에서 구하소서",
-    thumbnailVertical: "/images/recommendcontent_img.png",
-  },
-  {
-    id: 3,
-    title: "다만 악에서 구하소서 악에서 구하소서보이",
-    thumbnailVertical: "/images/recommendcontent_img.png",
-  },
-  {
-    id: 4,
-    title: "다만 악에서 구하소서",
-    thumbnailVertical: "/images/recommendcontent_img.png",
-  },
-  {
-    id: 5,
-    title: "다만 악에서 구하소서",
-    thumbnailVertical: "/images/recommendcontent_img.png",
-  },
-  {
-    id: 6,
-    title: "다만 악에서 구하소서 악에서 구하소서보이",
-    thumbnailVertical: "/images/recommendcontent_img.png",
-  },
-];
+import { Loader2 } from "lucide-react";
+import { SearchTip } from "@entities/search/components";
+import { useInfiniteSearchList } from "@entities/search/hooks";
+import { useMediaLink } from "@shared/hooks";
 
 interface SearchResultProps {
   keyword?: string;
 }
 
 export default function SearchResult({ keyword }: SearchResultProps) {
-  const searchQuery = keyword ?? "-ui";
-  const hasSearched = searchQuery !== "-ui";
+  const hasSearched = !!keyword;
+  const { getMediaHref } = useMediaLink();
 
-  const filteredResults = hasSearched
-    ? MOCK_CONTENTS.filter((item) =>
-        item.title.toLowerCase().includes(searchQuery.toLowerCase()),
-      )
-    : [];
+  const { searchList, isFetching, observerRef, isFetchingNextPage } =
+    useInfiniteSearchList({
+      page: 0,
+      size: 24,
+      searchWord: keyword,
+    });
 
-  const hasResults = filteredResults.length > 0;
+  const hasResults = searchList.length > 0;
 
-  // 결과 있을 때만 gap-y-20 → gap-y-10 효과를 위해 -mt-10 적용
   if (!hasSearched) {
     return (
       <>
-        <div className="border border-ot-gray-700 w-full" />
+        <div className="border-ot-gray-700 w-full border" />
         <SearchTip />
       </>
     );
   }
 
-  if (!hasResults) {
+  if (!isFetching && !hasResults) {
     return (
       <div className="flex flex-col items-center gap-y-20">
         <p className="text-ot-text text-2xl">
-          <span className="font-bold">"{searchQuery}"</span>에 대한 검색 결과가
+          <span className="font-bold">"{keyword}"</span>에 대한 검색 결과가
           없습니다
         </p>
-        <div className="border border-ot-gray-700 w-full" />
+        <div className="border-ot-gray-700 w-full border" />
         <SearchTip />
       </div>
     );
   }
 
   return (
-    <div className="flex flex-col gap-y-8 -mt-10">
+    <div className="-mt-10 flex flex-col gap-y-8">
       <p className="text-ot-text text-2xl">
-        <span className="font-bold">"{searchQuery}"</span>에 대한 검색 결과
+        <span className="font-bold">"{keyword}"</span>에 대한 검색 결과
       </p>
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 gap-6">
-        {filteredResults.map((item) => (
-          <div key={item.id}>
-            <div className="relative w-full aspect-5/7">
+      <div className="grid grid-cols-2 gap-6 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
+        {searchList.map((item) => (
+          <div key={`${item.mediaType}-${item.mediaId}`}>
+            <div className="bg-ot-gray-800 relative aspect-5/7 w-full rounded-lg">
               <Link
-                key={item.id}
-                href={`/contents/${item.id}`}
+                href={getMediaHref(item.mediaId, item.mediaType, {
+                  type: "search",
+                })}
                 className="block"
               >
                 <Image
-                  src={item.thumbnailVertical}
+                  src={item.posterUrl}
                   alt={item.title}
                   fill
                   sizes="(min-width: 1024px) 25vw, (min-width: 768px) 33vw, 50vw"
-                  className="object-cover rounded-lg"
+                  className="rounded-lg object-cover"
                 />
               </Link>
             </div>
           </div>
         ))}
+      </div>
+
+      <div ref={observerRef} className="flex h-4 justify-center">
+        {isFetchingNextPage && (
+          <Loader2
+            className="text-ot-placeholder mt-1 animate-spin"
+            size={20}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/entities/search/components/SearchResult.tsx
+++ b/src/entities/search/components/SearchResult.tsx
@@ -12,8 +12,9 @@ interface SearchResultProps {
 }
 
 export default function SearchResult({ keyword }: SearchResultProps) {
-  const hasSearched = !!keyword;
   const { getMediaHref } = useMediaLink();
+
+  const hasSearched = (keyword?.trim().length ?? 0) >= 2;
 
   const { searchList, isFetching, observerRef, isFetchingNextPage } =
     useInfiniteSearchList({

--- a/src/entities/search/hooks/index.ts
+++ b/src/entities/search/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useInfiniteSearchList } from "./useSearch";

--- a/src/entities/search/hooks/useSearch.ts
+++ b/src/entities/search/hooks/useSearch.ts
@@ -1,0 +1,31 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { SearchItem, searchApi } from "@entities/search/api";
+import { BasePaginationParams } from "@shared/types";
+import { useInfiniteScroll } from "@/shared/hooks";
+
+export const useInfiniteSearchList = ({
+  page,
+  size,
+  searchWord,
+}: BasePaginationParams) => {
+  const query = useInfiniteQuery({
+    queryKey: ["search", { page, size, searchWord }],
+    queryFn: ({ pageParam = 0 }) =>
+      searchApi({ page: pageParam as number, size, searchWord }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => {
+      const { currentPage, totalPage } = lastPage.pageInfo;
+      return currentPage + 1 < totalPage ? currentPage + 1 : undefined;
+    },
+  });
+
+  const { observerRef } = useInfiniteScroll({
+    hasNextPage: query.hasNextPage,
+    isFetchingNextPage: query.isFetchingNextPage,
+    fetchNextPage: query.fetchNextPage,
+  });
+
+  const searchList: SearchItem[] =
+    query.data?.pages.flatMap((page) => page.dataList) ?? [];
+  return { ...query, searchList, observerRef };
+};

--- a/src/entities/search/hooks/useSearch.ts
+++ b/src/entities/search/hooks/useSearch.ts
@@ -10,9 +10,10 @@ export const useInfiniteSearchList = ({
 }: BasePaginationParams) => {
   const query = useInfiniteQuery({
     queryKey: ["search", { page, size, searchWord }],
-    queryFn: ({ pageParam = 0 }) =>
+    queryFn: ({ pageParam = page }) =>
       searchApi({ page: pageParam as number, size, searchWord }),
-    initialPageParam: 0,
+    initialPageParam: page,
+    enabled: !!searchWord && searchWord.trim().length >= 2,
     getNextPageParam: (lastPage) => {
       const { currentPage, totalPage } = lastPage.pageInfo;
       return currentPage + 1 < totalPage ? currentPage + 1 : undefined;


### PR DESCRIPTION
## 📝 작업 내용

> 검색 API 연동 + 무한스크롤 구현
> - 스웨거 스펙상 검색어가 2글자 이상부터 검색이 가능하므로 2글자 미만 입력 시 alert이 뜨도록 구현했습니다.
> - 콘텐츠 클릭 시, 상세페이지 redirect될 때 `playlist="search"`가 나오도록 구현했습니다.

### 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. src에 이미지 url만 등록하면 됩니다. -->

| 구현 내용 |             2글자 미만 입력시 (0, 1글자)              |       
| :-------: | :-------------------------: | 
|    GIF    | <img src = "https://github.com/user-attachments/assets/65fb13d2-89a2-4286-b62d-338b486f2631" width ="700"> | 

- 검색 기능 + 무한스크롤 (테스트를 위해 size=3으로 잡음. 기본 size: 24 (6의 배수))


https://github.com/user-attachments/assets/fc65c121-195e-452a-8893-fa97cae0f5c8


- 콘텐츠 클릭 시 상세페이지 이동


https://github.com/user-attachments/assets/f4fd70f3-5fec-4677-af12-d9c8cf8677e9




## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

`SearchInput.tsx`

- `handleKeyDown`에서 `submitSearch` 호출 시 이미 엔터(enter)로 한 번, 그리고 IME(한글 조합) 때문에 keydown 이벤트가 두 번 발생하는 문제가 있어 `e.nativeEvent.isComposing` 체크로 막았습니다.

```ts
const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
  if (e.key === "Enter" && !e.nativeEvent.isComposing) {
    submitSearch(inputValue.trim());
  }
};
```

## ☑️ 체크 리스트

> 체크 리스트를 확인해주세요

- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?

## #️⃣ 연관된 이슈

> ex) #115 

## 💬 리뷰 요구사항

> - 무한스크롤 영상에서 속도가 느린 이유는 무한스크롤을 보여드리기 위해 임의로 network 속도를 늦춰서 그런 것 입니다! 참고해주세용 실제로는 매우 빠르게 로드됩니다.
> - 또한 영상 촬영을 위해 임의로 size:3 으로 잡았습니다. 실제로는 기본 6의 배수로 지정되며 기본값은 24입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 검색 결과를 서버와 연동해 실시간으로 표시
  * 무한 스크롤 방식의 페이징 지원 및 다음 페이지 자동 로드
  * 검색 결과 항목별 상세 링크 및 이미지 표시 개선
  * 하단 로딩 인디케이터 추가

* **Bug Fixes**
  * 검색어 최소 2자 검증 추가
  * IME(한글 등) 입력 중 Enter 처리 개선
  * 검색 입력창 안내 문구 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->