### PR TITLE
[HOTFIX]: useHls cdn 추가

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,14 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  async rewrites() {
+    return [
+      {
+        source: "/cdn-proxy/:path*",
+        destination: "https://cdn.openthetaste.cloud/:path*",
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/entities/player/hooks/useHls.ts
+++ b/src/entities/player/hooks/useHls.ts
@@ -4,47 +4,47 @@ import { useEffect, useRef } from "react";
 import Hls, { Level } from "hls.js";
 
 interface UseHlsProps {
-  src: string; // 영상 src
+  src: string;
   videoRef: React.RefObject<HTMLVideoElement | null>;
   onLevels?: (levels: Level[]) => void;
   startTime?: number;
 }
 
+const toProxySrc = (src: string) =>
+  src.replace("https://cdn.openthetaste.cloud", "/cdn-proxy");
+
 export const useHls = ({ src, videoRef, onLevels, startTime }: UseHlsProps) => {
   const hlsRef = useRef<Hls | null>(null);
 
   useEffect(() => {
-    // if (!videoRef.current) return;
     if (!videoRef.current || !src) return;
+
+    const proxySrc = toProxySrc(src);
 
     if (Hls.isSupported()) {
       const hls = new Hls();
       hlsRef.current = hls;
 
-      // FIXME: 아래 코드 주석 해제 해야 함
-      hls.loadSource(src); // m3u8 파일 로드
-
-      // hls.loadSource("https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8"); // 임시테스트용
+      hls.loadSource(proxySrc);
       hls.attachMedia(videoRef.current);
-      // hls엔진을 video 태그에 연결 -> 여기서부터 video가 hls 기반으로 재생 가능하게 됨
 
       hls.on(Hls.Events.MANIFEST_PARSED, () => {
         if (onLevels) {
-          onLevels(hls.levels); // 화질 목록 배열 생성 완료
+          onLevels(hls.levels);
         }
         if (startTime && videoRef.current) {
-          videoRef.current.currentTime = startTime; // 이어보기 구현
+          videoRef.current.currentTime = startTime;
         }
       });
 
       return () => {
         if (document.pictureInPictureElement) return;
-        // cleanup
         hls.destroy();
         hlsRef.current = null;
       };
     } else if (videoRef.current.canPlayType("application/vnd.apple.mpegurl")) {
-      videoRef.current.src = src; // safari 대응
+      videoRef.current.setAttribute("referrerpolicy", "no-referrer");
+      videoRef.current.src = proxySrc;
       if (startTime) videoRef.current.currentTime = startTime;
     }
   }, [src]);


### PR DESCRIPTION
## 📝 작업 내용

> **문제**
> HLS 영상 재생 시 CloudFront에서 Referer 기반으로 요청을 차단해 403 에러 발생
> 
> **원인**
> 브라우저가 페이지에서 요청할 때 Referer 헤더가 자동으로 붙고, CloudFront가 허용되지 않은 Referer를 차단
> 
> **해결**
> - `next.config.ts`에 `/cdn-proxy` rewrites 추가
> - `useHls`에서 CDN URL을 프록시 경로로 변환
> - 같은 도메인으로 요청되어 Referer 문제 우회

### 📷 스크린샷


## 🖥️ 주요 코드 설명



## ☑️ 체크 리스트

> 체크 리스트를 확인해주세요

- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?

## #️⃣ 연관된 이슈

> ex) # 이슈번호

## 💬 리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * CDN 프록시를 통한 비디오 콘텐츠 배포 경로 추가
  * HLS 비디오 스트림 로딩 메커니즘 업데이트
  * Safari 브라우저 비디오 재생 처리 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->