### PR TITLE
[OT-288] [FIX]: 1차 QA 수정 - 상세페이지

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -20,7 +20,7 @@ const nextConfig: NextConfig = {
     return [
       {
         source: "/cdn-proxy/:path*",
-        destination: "https://cdn.openthetaste.cloud/:path*",
+        destination: `${process.env.NEXT_PUBLIC_CDN_BASE_URL}/:path*`,
       },
     ];
   },

--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,14 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  async rewrites() {
+    return [
+      {
+        source: "/cdn-proxy/:path*",
+        destination: "https://cdn.openthetaste.cloud/:path*",
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+import { CircleAlert } from "lucide-react";
+import { CommonButton } from "@shared/components";
+
+export default function NotFound() {
+  return (
+    <div className="bg-ot-background text-ot-text flex min-h-screen flex-col items-center justify-center gap-4 px-6">
+      <CircleAlert
+        className="text-ot-primary-400 mb-2"
+        size={80}
+        strokeWidth={1.5}
+      />
+
+      <h1 className="text-2xl font-bold tracking-tight">
+        현재 페이지를 찾을 수 없습니다.
+      </h1>
+
+      <p className="text-ot-placeholder mb-4 text-center leading-relaxed">
+        홈페이지로 이동해 다양한 콘텐츠를 즐겨보세요!
+      </p>
+
+      <Link href="/">
+        <CommonButton variant="primary" className="h-12 px-10 font-semibold">
+          홈으로 가기
+        </CommonButton>
+      </Link>
+    </div>
+  );
+}

--- a/src/entities/player/hooks/useHls.ts
+++ b/src/entities/player/hooks/useHls.ts
@@ -4,7 +4,7 @@ import { useEffect, useRef } from "react";
 import Hls, { Level } from "hls.js";
 
 interface UseHlsProps {
-  src: string;
+  src: string; // 영상 src
   videoRef: React.RefObject<HTMLVideoElement | null>;
   onLevels?: (levels: Level[]) => void;
   startTime?: number;
@@ -25,12 +25,13 @@ export const useHls = ({ src, videoRef, onLevels, startTime }: UseHlsProps) => {
       const hls = new Hls();
       hlsRef.current = hls;
 
-      hls.loadSource(proxySrc);
+      hls.loadSource(proxySrc); // m3u8 파일 로드
       hls.attachMedia(videoRef.current);
+      // hls엔진을 video 태그에 연결 -> 여기서부터 video가 hls 기반으로 재생 가능하게 됨
 
       hls.on(Hls.Events.MANIFEST_PARSED, () => {
         if (onLevels) {
-          onLevels(hls.levels);
+          onLevels(hls.levels); // 화질 목록 배열 생성 완료
         }
         if (startTime && videoRef.current) {
           videoRef.current.currentTime = startTime;
@@ -38,7 +39,8 @@ export const useHls = ({ src, videoRef, onLevels, startTime }: UseHlsProps) => {
       });
 
       return () => {
-        if (document.pictureInPictureElement) return;
+        if (document.pictureInPictureElement) return; // 이어보기 구현
+        // clean up
         hls.destroy();
         hlsRef.current = null;
       };

--- a/src/entities/player/hooks/useHls.ts
+++ b/src/entities/player/hooks/useHls.ts
@@ -4,47 +4,47 @@ import { useEffect, useRef } from "react";
 import Hls, { Level } from "hls.js";
 
 interface UseHlsProps {
-  src: string; // 영상 src
+  src: string;
   videoRef: React.RefObject<HTMLVideoElement | null>;
   onLevels?: (levels: Level[]) => void;
   startTime?: number;
 }
 
+const toProxySrc = (src: string) =>
+  src.replace("https://cdn.openthetaste.cloud", "/cdn-proxy");
+
 export const useHls = ({ src, videoRef, onLevels, startTime }: UseHlsProps) => {
   const hlsRef = useRef<Hls | null>(null);
 
   useEffect(() => {
-    // if (!videoRef.current) return;
     if (!videoRef.current || !src) return;
+
+    const proxySrc = toProxySrc(src);
 
     if (Hls.isSupported()) {
       const hls = new Hls();
       hlsRef.current = hls;
 
-      // FIXME: 아래 코드 주석 해제 해야 함
-      hls.loadSource(src); // m3u8 파일 로드
-
-      // hls.loadSource("https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8"); // 임시테스트용
+      hls.loadSource(proxySrc);
       hls.attachMedia(videoRef.current);
-      // hls엔진을 video 태그에 연결 -> 여기서부터 video가 hls 기반으로 재생 가능하게 됨
 
       hls.on(Hls.Events.MANIFEST_PARSED, () => {
         if (onLevels) {
-          onLevels(hls.levels); // 화질 목록 배열 생성 완료
+          onLevels(hls.levels);
         }
         if (startTime && videoRef.current) {
-          videoRef.current.currentTime = startTime; // 이어보기 구현
+          videoRef.current.currentTime = startTime;
         }
       });
 
       return () => {
         if (document.pictureInPictureElement) return;
-        // cleanup
         hls.destroy();
         hlsRef.current = null;
       };
     } else if (videoRef.current.canPlayType("application/vnd.apple.mpegurl")) {
-      videoRef.current.src = src; // safari 대응
+      videoRef.current.setAttribute("referrerpolicy", "no-referrer");
+      videoRef.current.src = proxySrc;
       if (startTime) videoRef.current.currentTime = startTime;
     }
   }, [src]);

--- a/src/entities/player/hooks/useHls.ts
+++ b/src/entities/player/hooks/useHls.ts
@@ -11,7 +11,7 @@ interface UseHlsProps {
 }
 
 const toProxySrc = (src: string) =>
-  src.replace("https://cdn.openthetaste.cloud", "/cdn-proxy");
+  src.replace(process.env.NEXT_PUBLIC_CDN_BASE_URL!, "/cdn-proxy");
 
 export const useHls = ({ src, videoRef, onLevels, startTime }: UseHlsProps) => {
   const hlsRef = useRef<Hls | null>(null);

--- a/src/entities/video-contents/components/ContentsContainer.tsx
+++ b/src/entities/video-contents/components/ContentsContainer.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import Link from "next/link";
+import { AxiosError } from "axios";
+import { Clapperboard } from "lucide-react";
 import {
   ContentsMainSection,
   EpisodeSideSection,
@@ -10,7 +13,8 @@ import {
   useContentsDetail,
   useSeriesDetail,
 } from "@entities/video-contents/hooks";
-import { PlaylistParams } from "@shared/types";
+import { CommonButton } from "@shared/components";
+import { ApiError, PlaylistParams } from "@shared/types";
 
 interface ContentsContainerProps {
   mediaId: number;
@@ -38,14 +42,48 @@ export default function ContentsContainer({
     data: seriesData,
     isLoading: seriesLoading,
     isError: seriesError,
+    error: seriesErrorObj,
   } = useSeriesDetail(isSeries ? mediaId : 0);
 
   const data = isSeries ? seriesData : contentsData;
   const isLoading = isSeries ? seriesLoading : contentsLoading;
   const isError = isSeries ? seriesError : contentsError;
 
-  if (isLoading) return <div>로딩중...</div>;
-  if (isError || !data) return <div>콘텐츠를 찾을 수 없습니다.</div>;
+  const isNoEpisode =
+    isSeries &&
+    isError &&
+    seriesErrorObj instanceof AxiosError &&
+    (seriesErrorObj as AxiosError<ApiError>).response?.data?.code === "B108";
+
+  if (isLoading) return <div className="flex-1">로딩중...</div>;
+
+  if (isNoEpisode) {
+    return (
+      <div className="text-ot-text flex flex-1 flex-col items-center justify-center gap-4 px-6">
+        <Clapperboard
+          className="text-ot-primary-400 mb-2"
+          size={80}
+          strokeWidth={1.5}
+        />
+        <h1 className="text-2xl font-bold tracking-tight">
+          해당 시리즈에 에피소드가 아직 없어요
+        </h1>
+        <p className="text-ot-placeholder mb-4 text-center leading-relaxed">
+          콘텐츠를 열심히 준비 중이에요.
+          <br />
+          조금만 기다려 주세요!
+        </p>
+        <Link href="/">
+          <CommonButton variant="primary" className="h-12 px-10 font-semibold">
+            홈으로 가기
+          </CommonButton>
+        </Link>
+      </div>
+    );
+  }
+
+  if (isError || !data)
+    return <div className="flex-1">콘텐츠를 찾을 수 없습니다.</div>;
 
   return (
     <div className="mx-24 my-7">

--- a/src/entities/video-contents/components/EpisodeSideSection.tsx
+++ b/src/entities/video-contents/components/EpisodeSideSection.tsx
@@ -53,10 +53,19 @@ export default function EpisodeSideSection({
           </p>
           <div className="flex-1 overflow-y-auto">
             {isLoading ? (
-              <div className="py-4 text-center">로딩중...</div>
+              <div className="flex h-full items-center justify-center">
+                <Loader2
+                  className="text-ot-placeholder animate-spin"
+                  size={20}
+                />
+              </div>
             ) : isError ? (
-              <div className="py-4 text-center">
+              <div className="text-ot-placeholder flex h-full items-center justify-center text-sm">
                 에피소드를 불러올 수 없습니다.
+              </div>
+            ) : otherEpisodes.length === 0 ? (
+              <div className="text-ot-placeholder flex h-full items-center justify-center text-sm">
+                다음 에피소드가 없습니다.
               </div>
             ) : (
               <>

--- a/src/entities/video-contents/components/EpisodeSideSection.tsx
+++ b/src/entities/video-contents/components/EpisodeSideSection.tsx
@@ -60,11 +60,11 @@ export default function EpisodeSideSection({
                 />
               </div>
             ) : isError ? (
-              <div className="text-ot-placeholder flex h-full items-center justify-center text-sm">
+              <div className="text-ot-placeholder flex h-full items-center justify-center">
                 에피소드를 불러올 수 없습니다.
               </div>
             ) : otherEpisodes.length === 0 ? (
-              <div className="text-ot-placeholder flex h-full items-center justify-center text-sm">
+              <div className="text-ot-gray-600 flex h-full items-center justify-center">
                 다음 에피소드가 없습니다.
               </div>
             ) : (

--- a/src/entities/video-contents/components/SeriesSideSection.tsx
+++ b/src/entities/video-contents/components/SeriesSideSection.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { Loader2 } from "lucide-react";
+import { Loader2, VideoOff } from "lucide-react";
 import { useSeriesEpisodeList } from "@entities/video-contents/hooks";
 import { useInfiniteScroll } from "@shared/hooks";
 
@@ -27,47 +27,60 @@ export default function SeriesSideSection({
     fetchNextPage,
   });
 
-  if (isLoading)
-    return <div className="w-full max-w-134 shrink-0">로딩중...</div>;
-  if (isError)
-    return (
-      <div className="w-full max-w-134 shrink-0">
-        에피소드를 불러올 수 없습니다.
-      </div>
-    );
-
   return (
     <div className="w-full max-w-134 shrink-0">
       <div className="flex h-[80vh] flex-col overflow-y-auto rounded-lg px-5 py-4">
         <p className="border-b pb-3 text-2xl font-bold">에피소드</p>
-        {episodes.map((ep) => (
-          <Link
-            key={ep.mediaId}
-            href={`/contents/${seriesMediaId}/episode/${ep.mediaId}?type=SERIES`}
-          >
-            <button className="text-ot-text hover:bg-ot-gray-900 flex w-full items-center gap-6 p-4 transition">
-              <div className="bg-ot-gray-800 relative aspect-4/3 w-full max-w-25 shrink-0 overflow-hidden rounded-lg">
-                {ep.thumbnailUrl && (
-                  <Image
-                    src={ep.thumbnailUrl}
-                    fill
-                    className="object-cover"
-                    alt={ep.title}
-                  />
-                )}
-              </div>
-              <p className="text-left text-xl font-semibold">{ep.title}</p>
-            </button>
-          </Link>
-        ))}
-        <div ref={observerRef} className="flex h-2 justify-center">
-          {isFetchingNextPage && (
-            <Loader2
-              className="text-ot-placeholder mt-4 animate-spin"
-              size={20}
+
+        {isLoading ? (
+          <div className="flex flex-1 items-center justify-center">
+            <Loader2 className="text-ot-placeholder animate-spin" size={24} />
+          </div>
+        ) : isError || episodes.length === 0 ? (
+          <div className="flex flex-1 flex-col items-center justify-center gap-3">
+            <VideoOff
+              className="text-ot-placeholder"
+              size={36}
+              strokeWidth={1.2}
             />
-          )}
-        </div>
+            <p className="text-ot-placeholder text-sm">
+              {isError
+                ? "에피소드를 불러올 수 없습니다."
+                : "등록된 에피소드가 없습니다."}
+            </p>
+          </div>
+        ) : (
+          <>
+            {episodes.map((ep) => (
+              <Link
+                key={ep.mediaId}
+                href={`/contents/${seriesMediaId}/episode/${ep.mediaId}?type=SERIES`}
+              >
+                <button className="text-ot-text hover:bg-ot-gray-900 flex w-full items-center gap-6 p-4 transition">
+                  <div className="bg-ot-gray-800 relative aspect-4/3 w-full max-w-25 shrink-0 overflow-hidden rounded-lg">
+                    {ep.thumbnailUrl && (
+                      <Image
+                        src={ep.thumbnailUrl}
+                        fill
+                        className="object-cover"
+                        alt={ep.title}
+                      />
+                    )}
+                  </div>
+                  <p className="text-left text-xl font-semibold">{ep.title}</p>
+                </button>
+              </Link>
+            ))}
+            <div ref={observerRef} className="flex h-2 justify-center">
+              {isFetchingNextPage && (
+                <Loader2
+                  className="text-ot-placeholder mt-4 animate-spin"
+                  size={20}
+                />
+              )}
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/entities/video-contents/components/SingleSideSection.tsx
+++ b/src/entities/video-contents/components/SingleSideSection.tsx
@@ -33,10 +33,8 @@ export default function SingleSideSection({
     }),
   );
 
-  const { items, fetchNextPage, hasNextPage, isFetchingNextPage } = usePlaylist(
-    source,
-    mediaId,
-  );
+  const { items, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    usePlaylist(source, mediaId);
   const { observerRef } = useInfiniteScroll({
     hasNextPage,
     isFetchingNextPage,
@@ -58,34 +56,49 @@ export default function SingleSideSection({
             다음 재생목록
           </p>
           <div className="flex-1 overflow-y-auto">
-            {items.map((item: PlaylistItem) => (
-              <Link
-                key={item.mediaId}
-                href={getMediaHref(item.mediaId, item.mediaType, source)}
-              >
-                <button className="text-ot-text hover:bg-ot-gray-900 flex w-full items-center gap-6 p-4 transition">
-                  <div className="bg-ot-gray-800 relative aspect-4/3 w-full max-w-25 shrink-0 overflow-hidden rounded-lg">
-                    {item.thumbnailUrl && (
-                      <Image
-                        src={item.thumbnailUrl}
-                        fill
-                        className="object-cover"
-                        alt={item.title}
-                      />
-                    )}
-                  </div>
-                  <p className="text-xl font-semibold">{item.title}</p>
-                </button>
-              </Link>
-            ))}
-            <div ref={observerRef} className="flex h-2 justify-center">
-              {isFetchingNextPage && (
+            {isLoading ? (
+              <div className="flex h-full items-center justify-center">
                 <Loader2
-                  className="text-ot-placeholder mt-4 animate-spin"
+                  className="text-ot-placeholder animate-spin"
                   size={20}
                 />
-              )}
-            </div>
+              </div>
+            ) : items.length === 0 ? (
+              <div className="text-ot-gray-600 flex h-full items-center justify-center">
+                현재 재생목록이 없습니다.
+              </div>
+            ) : (
+              <>
+                {items.map((item: PlaylistItem) => (
+                  <Link
+                    key={item.mediaId}
+                    href={getMediaHref(item.mediaId, item.mediaType, source)}
+                  >
+                    <button className="text-ot-text hover:bg-ot-gray-900 flex w-full items-center gap-6 p-4 transition">
+                      <div className="bg-ot-gray-800 relative aspect-4/3 w-full max-w-25 shrink-0 overflow-hidden rounded-lg">
+                        {item.thumbnailUrl && (
+                          <Image
+                            src={item.thumbnailUrl}
+                            fill
+                            className="object-cover"
+                            alt={item.title}
+                          />
+                        )}
+                      </div>
+                      <p className="text-xl font-semibold">{item.title}</p>
+                    </button>
+                  </Link>
+                ))}
+                <div ref={observerRef} className="flex h-2 justify-center">
+                  {isFetchingNextPage && (
+                    <Loader2
+                      className="text-ot-placeholder mt-4 animate-spin"
+                      size={20}
+                    />
+                  )}
+                </div>
+              </>
+            )}
           </div>
         </div>
       )}

--- a/src/entities/video-contents/hooks/usePlaylist.ts
+++ b/src/entities/video-contents/hooks/usePlaylist.ts
@@ -63,12 +63,20 @@ export const usePlaylist = (source: PlaylistSource, excludeMediaId: number) => {
           return trendingListApi(baseParams) as Promise<PlaylistResponse>;
       }
     },
-    getNextPageParam: (lastPage) =>
-      lastPage.pageInfo.currentPage + 1 < lastPage.pageInfo.totalPage
+    getNextPageParam: (lastPage) => {
+      if (!lastPage.dataList || lastPage.dataList.length === 0)
+        return undefined;
+      return lastPage.pageInfo.currentPage + 1 < lastPage.pageInfo.totalPage
         ? lastPage.pageInfo.currentPage + 1
-        : undefined,
+        : undefined;
+    },
   });
-  const items = query.data?.pages.flatMap((page) => page.dataList) ?? [];
+
+  const rawItems = query.data?.pages.flatMap((page) => page.dataList) ?? [];
+  const items = rawItems.filter(
+    (item, index, self) =>
+      self.findIndex((i) => i.mediaId === item.mediaId) === index,
+  );
 
   return { ...query, items };
 };

--- a/src/shared/api/apiClient.ts
+++ b/src/shared/api/apiClient.ts
@@ -1,5 +1,10 @@
-import axios, { AxiosResponse, InternalAxiosRequestConfig } from "axios";
+import axios, {
+  AxiosError,
+  AxiosResponse,
+  InternalAxiosRequestConfig,
+} from "axios";
 import { reissueApi } from "@shared/api/reissueApi";
+import { ApiError } from "@shared/types";
 
 const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
@@ -7,7 +12,6 @@ interface RetryConfig extends InternalAxiosRequestConfig {
   _retry?: boolean;
 }
 
-//동시성 제어 변수
 let isRefreshing = false;
 let refreshSubscribers: Array<(error?: Error) => void> = [];
 
@@ -29,63 +33,45 @@ export const api = axios.create({
 
 api.interceptors.response.use(
   (response: AxiosResponse) => response,
-  async (error) => {
+  async (error: AxiosError<ApiError>) => {
     const originalRequest = error.config as RetryConfig;
-    const message = error.response?.data?.message || error.message;
 
     if (error.response?.status !== 401) {
-      return Promise.reject(new Error(message));
+      // 원본 AxiosError를 그대로 reject — response.data 접근 가능하게 유지
+      return Promise.reject(error);
     }
 
-    // 이미 재시도한 요청이면 에러 반환
     if (originalRequest._retry) {
-      return Promise.reject(new Error(message));
+      return Promise.reject(error);
     }
 
     originalRequest._retry = true;
 
     if (isRefreshing) {
-      console.log("[대기] 다른 요청이 토큰 갱신 중:", originalRequest.url);
       return new Promise((resolve, reject) => {
         addRefreshSubscriber((error) => {
           if (error) {
-            console.log("[대기 요청 실패]", originalRequest.url);
             reject(error);
           } else {
-            console.log("[대기 요청 재시도]", originalRequest.url);
-            api(originalRequest)
-              .then(resolve)
-              .catch(reject);
+            api(originalRequest).then(resolve).catch(reject);
           }
         });
       });
     }
 
-    //갱신 시작
     isRefreshing = true;
-    console.log("[첫 요청이 토큰 갱신 시작]", originalRequest.url);
 
     try {
       await reissueApi.refresh();
-      
-      console.log("[토큰 갱신 성공 - 대기 요청들 깨우기]");
-      
-      // 대기 중인 모든 요청들에게 성공 알림
       onRefreshed();
-
-      console.log("[원래 요청 재시도]", originalRequest.url);
       return api(originalRequest);
-      
     } catch (refreshError) {
-      console.error("[토큰 갱신 실패]", refreshError);
-      
-      const error = refreshError instanceof Error
-        ? refreshError
-        : new Error("토큰 갱신 실패");
+      const error =
+        refreshError instanceof Error
+          ? refreshError
+          : new Error("토큰 갱신 실패");
       onRefreshed(error);
-
       return Promise.reject(error);
-      
     } finally {
       isRefreshing = false;
     }

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -9,3 +9,4 @@ export * from "./mypage/dashboard";
 export * from "./pagination";
 export * from "./playlistSource";
 export * from "./mediaType";
+export * from "./apiError";


### PR DESCRIPTION
## 📝 작업 내용

> - 에러 관련 UI 구현
>    - 시리즈 원본 - 에피소드 없으면 에러 페이지 return
>    - 이외 404 에러 -> `not-found.tsx`
> - 상세 페이지 - 재생목록 
>    - 기능 - 무한스크롤 ) 다음 `pageInfo.dataList === []` 일 경우, 스크롤 막음
>    - UI - 재생목록 빈 배열일 때, text 표시
> - hotfix로 수정했던, `next.config.ts`, `useHls.ts` url 하드코딩 제거 -> env 변수 사용
> - `apiClient.ts` 에러 반환하도록 수정


### 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. src에 이미지 url만 등록하면 됩니다. -->

| 구현 내용 |             에러 - 에피소드 등록 x              |         
| :-------: | :-------------------------: |
|    GIF    | <img src = "https://github.com/user-attachments/assets/daa9addb-3b7b-42a7-a76f-af9f530cb2c7" width ="700"> | 

| 구현 내용 |             재생목록 (playlist)              |         
| :-------: | :-------------------------: |
|    GIF    | <img src = "https://github.com/user-attachments/assets/23908365-19ae-4440-9038-6f96ceecbc31" width ="700"> | 

| 구현 내용 |             재생목록 (에피소드)              |         
| :-------: | :-------------------------: |
|    GIF    | <img src = "https://github.com/user-attachments/assets/73d534ef-e08b-449e-913d-37b7a0e3ec4a" width ="700"> |

| 구현 내용 |    404 (not-found)          |         
| :-------: | :-------------------------: |
|    GIF    | <img src = "https://github.com/user-attachments/assets/0f9ffaa6-08b1-421b-a0e8-3883667bf3c6" width ="700"> | 



## 🖥️ 주요 코드 설명


## ☑️ 체크 리스트

> 체크 리스트를 확인해주세요

- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?

## #️⃣ 연관된 이슈

> ex) #122 

## 💬 리뷰 요구사항

> env 추가해주세요! 이외의 나머지 추가 작업은 멘토링 이후 작업 마무리하도록 하겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 전체 화면 404 페이지 추가 (안내 및 홈 복귀 버튼 포함)
  * 시리즈에 에피소드가 없을 때 전용 안내 상태 추가

* **버그 수정**
  * 재생목록 중복 항목 제거
  * API/요청 관련 오류 처리 개선

* **개선사항**
  * 로딩·빈 상태 UI 개선(스피너/아이콘/메시지)
  * 재생·사이드 패널의 빈 상태 처리 및 로딩 흐름 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->