### PR TITLE
[OT-301] [FEAT, FIX]: 플레이어 API 연동

### DIFF
--- a/src/entities/home/components/CustomRecommendCarousel.tsx
+++ b/src/entities/home/components/CustomRecommendCarousel.tsx
@@ -1,24 +1,24 @@
 "use client";
 
-import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
+import { useState } from "react";
 import { ContentCarousel } from "@entities/home/components";
 import { useMemberProfile } from "@entities/profile/hooks";
 import { useMediaLink } from "@shared/hooks";
-import { PlaylistItem } from "@/shared/types";
 import { useRadarRecommend } from "@/entities/custom/hooks";
+import { PlaylistItem } from "@/shared/types";
 
 export default function CustomRecommendCarousel() {
-    const [page, setPage] = useState(0);
-    const { data } = useRadarRecommend({ page, size: 20 });
-    const { data: profile } = useMemberProfile();
-    const items = data?.dataList ?? [];
-    const { getMediaHref } = useMediaLink();
+  const [page, setPage] = useState(0);
+  const { data } = useRadarRecommend({ page, size: 20 });
+  const { data: profile } = useMemberProfile();
+  const items = data?.dataList ?? [];
+  const { getMediaHref } = useMediaLink();
 
-    if (!items.length) return null;
+  if (!items.length) return null;
 
-    return (
+  return (
     <ContentCarousel
       title={`${profile?.nickname ?? ""}님의 커스텀 추천 플레이리스트`}
       itemWidth={180}
@@ -28,7 +28,7 @@ export default function CustomRecommendCarousel() {
       renderItem={(item: PlaylistItem) => (
         <Link
           href={getMediaHref(item.mediaId, item.mediaType, {
-            type: "history",
+            type: "recommend",
           })}
           className="block h-full w-full"
         >
@@ -40,7 +40,7 @@ export default function CustomRecommendCarousel() {
               className="object-cover"
             />
             <div className="absolute right-0 bottom-0 left-0 bg-gradient-to-t from-black/80 to-transparent p-2">
-              <p className="line-clamp-2 text-xs font-medium text-ot-text">
+              <p className="text-ot-text line-clamp-2 text-xs font-medium">
                 {item.title}
               </p>
             </div>

--- a/src/entities/player/api/index.ts
+++ b/src/entities/player/api/index.ts
@@ -1,0 +1,2 @@
+export { watchHistoryApi } from "./watchHistoryApi";
+export { playbackApi } from "./playbackApi";

--- a/src/entities/player/api/playbackApi.ts
+++ b/src/entities/player/api/playbackApi.ts
@@ -1,0 +1,5 @@
+import { api } from "@/shared/api";
+
+export const playbackApi = async (mediaId: number, positionSec: number) => {
+  await api.put("/playback", { mediaId, positionSec });
+};

--- a/src/entities/player/api/watchHistoryApi.ts
+++ b/src/entities/player/api/watchHistoryApi.ts
@@ -1,0 +1,5 @@
+import { api } from "@shared/api";
+
+export const watchHistoryApi = async (mediaId: number) => {
+  await api.put("/watch-history", { mediaId });
+};

--- a/src/entities/player/hooks/index.ts
+++ b/src/entities/player/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useHls } from "./useHls";
 export { useHideControls } from "./useHideControls";
+export { usePlayback } from "./usePlayback";

--- a/src/entities/player/hooks/useHls.ts
+++ b/src/entities/player/hooks/useHls.ts
@@ -8,12 +8,19 @@ interface UseHlsProps {
   videoRef: React.RefObject<HTMLVideoElement | null>;
   onLevels?: (levels: Level[]) => void;
   startTime?: number;
+  onReady?: () => void;
 }
 
 const toProxySrc = (src: string) =>
   src.replace(process.env.NEXT_PUBLIC_CDN_BASE_URL!, "/cdn-proxy");
 
-export const useHls = ({ src, videoRef, onLevels, startTime }: UseHlsProps) => {
+export const useHls = ({
+  src,
+  videoRef,
+  onLevels,
+  startTime,
+  onReady,
+}: UseHlsProps) => {
   const hlsRef = useRef<Hls | null>(null);
 
   useEffect(() => {
@@ -36,6 +43,7 @@ export const useHls = ({ src, videoRef, onLevels, startTime }: UseHlsProps) => {
         if (startTime && videoRef.current) {
           videoRef.current.currentTime = startTime;
         }
+        if (onReady) onReady();
       });
 
       return () => {

--- a/src/entities/player/hooks/usePlayback.ts
+++ b/src/entities/player/hooks/usePlayback.ts
@@ -1,0 +1,27 @@
+import { useEffect, useRef } from "react";
+import { playbackApi } from "@entities/player/api";
+
+interface usePlaybackProps {
+  mediaId: number;
+  getCurrentPostionSec: () => number;
+  isPlaying: boolean;
+}
+export const usePlayback = ({
+  mediaId,
+  getCurrentPostionSec,
+  isPlaying,
+}: usePlaybackProps) => {
+  const isPlayingRef = useRef(isPlaying);
+  isPlayingRef.current = isPlaying;
+
+  useEffect(() => {
+    const interval = setInterval(async () => {
+      if (!isPlayingRef.current) return;
+      try {
+        await playbackApi(mediaId, getCurrentPostionSec());
+      } catch {}
+    }, 10000);
+
+    return () => clearInterval(interval);
+  }, [mediaId]);
+};

--- a/src/entities/video-contents/components/ContentsMainSection.tsx
+++ b/src/entities/video-contents/components/ContentsMainSection.tsx
@@ -8,13 +8,14 @@ import { ChevronDown, Play } from "lucide-react";
 import { Badge, CommonButton, InteractionButton } from "@base-components";
 import { useToggleBookmark } from "@entities/bookmark/hooks";
 import { useLikes } from "@entities/likes/hooks";
+import { watchHistoryApi } from "@entities/player/api";
 import {
   ContentsDetailReponse,
   SeriesDetailReponse,
 } from "@entities/video-contents/api";
 import { DESCRIPTION_MAX_LENGTH } from "@entities/video-contents/constants";
 import { useSeriesEpisodeList } from "@entities/video-contents/hooks";
-import { MediaType } from "@/shared/types";
+import { MediaType } from "@shared/types";
 
 interface ContentsMainSectionProps {
   content: ContentsDetailReponse | SeriesDetailReponse;
@@ -52,9 +53,10 @@ export default function ContentsMainSection({
 
   const router = useRouter();
 
-  const handlePlay = () => {
+  const handlePlay = async () => {
     if (mediaType === "CONTENTS") {
       router.push(`/player/${mediaId}`);
+      await watchHistoryApi(mediaId).catch(() => {});
     } else {
       const resumeId =
         "resumeMediaId" in content ? content.resumeMediaId : null;
@@ -63,9 +65,9 @@ export default function ContentsMainSection({
 
       if (!targetId) return;
       router.push(`/contents/${mediaId}/episode/${targetId}?type=SERIES`);
+      await watchHistoryApi(targetId).catch(() => {});
     }
   };
-
   const truncatedDescription = (text: string) =>
     text.length <= DESCRIPTION_MAX_LENGTH
       ? text

--- a/src/entities/video-contents/components/EpisodeSideSection.tsx
+++ b/src/entities/video-contents/components/EpisodeSideSection.tsx
@@ -2,7 +2,8 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useAutoPlayStore } from "@store";
 import { Loader2 } from "lucide-react";
 import { ReviewSection } from "@entities/video-contents/components";
 import { useSeriesEpisodeList } from "@entities/video-contents/hooks";
@@ -39,6 +40,14 @@ export default function EpisodeSideSection({
   const otherEpisodes = episodes.filter(
     (ep) => ep.mediaId !== currentEpisodeId,
   );
+
+  const { setQueue } = useAutoPlayStore();
+
+  useEffect(() => {
+    if (episodes.length > 0) {
+      setQueue(episodes, currentEpisodeId);
+    }
+  }, [episodes.length, setQueue]);
 
   return (
     <div className="w-full max-w-134 shrink-0">

--- a/src/entities/video-contents/components/SingleSideSection.tsx
+++ b/src/entities/video-contents/components/SingleSideSection.tsx
@@ -49,7 +49,7 @@ export default function SingleSideSection({
   const { setQueue } = useAutoPlayStore();
   useEffect(() => {
     if (items.length > 0) {
-      setQueue(items, mediaId, source.type);
+      setQueue(items, mediaId, source);
     }
   }, [items.length, setQueue]);
 

--- a/src/entities/video-contents/components/SingleSideSection.tsx
+++ b/src/entities/video-contents/components/SingleSideSection.tsx
@@ -2,7 +2,8 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useAutoPlayStore } from "@store";
 import { Loader2 } from "lucide-react";
 import { ReviewSection } from "@entities/video-contents/components";
 import {
@@ -43,6 +44,14 @@ export default function SingleSideSection({
     fetchNextPage,
   });
   const { getMediaHref } = useMediaLink();
+
+  // playlist를 전역상태에 저장
+  const { setQueue } = useAutoPlayStore();
+  useEffect(() => {
+    if (items.length > 0) {
+      setQueue(items, mediaId, source.type);
+    }
+  }, [items.length, setQueue]);
 
   return (
     <div className="w-full max-w-134 shrink-0">

--- a/src/features/player/components/AutoPlayNextBanner.tsx
+++ b/src/features/player/components/AutoPlayNextBanner.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import Image from "next/image";
+import { useEffect, useRef, useState } from "react";
+import { Play, X } from "lucide-react";
+
+interface NextMediaInfo {
+  mediaId: number;
+  title: string;
+  thumbnailUrl: string;
+}
+
+interface AutoPlayNextBannerProps {
+  type: "contents" | "episode";
+  nextMedia: NextMediaInfo;
+  countdownSec?: number;
+  onConfirm: () => void;
+  onCancel: () => void;
+  showControls: boolean;
+}
+
+export const AutoPlayNextBanner = ({
+  type,
+  nextMedia,
+  countdownSec,
+  onConfirm,
+  onCancel,
+  showControls,
+}: AutoPlayNextBannerProps) => {
+  const defaultSec = countdownSec ?? (type === "contents" ? 15 : 5);
+  const [remaining, setRemaining] = useState(defaultSec);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    intervalRef.current = setInterval(() => {
+      setRemaining((prev) => {
+        if (prev <= 1) {
+          clearInterval(intervalRef.current!);
+          onConfirm();
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [onConfirm]);
+
+  const bottomClass = showControls ? "bottom-20" : "bottom-4";
+
+  if (type === "episode") {
+    return (
+      <div
+        className={`bg-ot-gray-900/90 hover:bg-ot-gray-800/90 absolute right-4 ${bottomClass} flex items-center gap-4 rounded-md px-3 py-3 shadow-lg backdrop-blur-sm transition-all`}
+      >
+        <div
+          className="relative h-14 w-22 shrink-0 cursor-pointer overflow-hidden rounded-md"
+          onClick={onConfirm}
+        >
+          <Image
+            src={nextMedia.thumbnailUrl}
+            alt={nextMedia.title}
+            fill
+            className="object-cover"
+          />
+        </div>
+
+        <div className="flex cursor-pointer flex-col gap-1" onClick={onConfirm}>
+          <p className="text-ot-text line-clamp-1 max-w-35 text-sm leading-tight font-semibold">
+            {nextMedia.title}
+          </p>
+          <p className="text-ot-gray-400 text-xs">{remaining}초 뒤 연속 재생</p>
+        </div>
+
+        <button
+          onClick={onCancel}
+          className="text-ot-gray-600 hover:text-ot-text ml-1 shrink-0 self-start p-1 transition-colors"
+          aria-label="자동재생 취소"
+        >
+          <X size={16} />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      onClick={onConfirm}
+      className={`bg-ot-gray-900/90 hover:bg-ot-gray-800/90 absolute right-4 ${bottomClass} flex items-center gap-3 rounded-md px-4 py-3 shadow-lg backdrop-blur-sm transition-all`}
+    >
+      <Play size={16} fill="currentColor" />
+      <span className="text-ot-text text-sm font-semibold whitespace-nowrap">
+        {remaining}초 후 다음 화 재생
+      </span>
+    </button>
+  );
+};

--- a/src/features/player/components/AutoPlayNextBanner.tsx
+++ b/src/features/player/components/AutoPlayNextBanner.tsx
@@ -50,7 +50,8 @@ export const AutoPlayNextBanner = ({
 
   const bottomClass = showControls ? "bottom-20" : "bottom-4";
 
-  if (type === "episode") {
+  // 콘텐츠
+  if (type === "contents") {
     return (
       <div
         className={`bg-ot-gray-900/90 hover:bg-ot-gray-800/90 absolute right-4 ${bottomClass} flex items-center gap-4 rounded-md px-3 py-3 shadow-lg backdrop-blur-sm transition-all`}
@@ -84,7 +85,7 @@ export const AutoPlayNextBanner = ({
       </div>
     );
   }
-
+  // 에피소드
   return (
     <button
       onClick={onConfirm}

--- a/src/features/player/components/VideoPlayer.tsx
+++ b/src/features/player/components/VideoPlayer.tsx
@@ -314,9 +314,8 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
     }
   };
 
+  // 뒤로가기
   const handleBack = async () => {
-    console.log("source:", source);
-    console.log("data:", data);
     isSavedRef.current = true;
     if (videoRef.current && !videoRef.current.paused) {
       videoRef.current.pause();
@@ -336,7 +335,6 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
       if (source.type === "topTag" && "index" in source) {
         params.set("index", String(source.index));
       } // topTag 플리인 경우, index도 붙여서 이동
-      console.log("이동 URL:", `/contents/${mediaId}?${params.toString()}`);
       router.push(`/contents/${mediaId}?${params.toString()}`);
     } else {
       router.push(`/contents/${mediaId}?type=CONTENTS`);
@@ -363,8 +361,13 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
     isSavedRef.current = true;
     const { queue, source } = useAutoPlayStore.getState();
     setQueue(queue, nextMedia.mediaId, source ?? undefined);
-    await watchHistoryApi(nextMedia.mediaId).catch(() => {}); // 자동재생 이후 시청이력 갱신
-    router.push(`/player/${nextMedia.mediaId}`);
+
+    if (nextMedia.mediaType === "SERIES") {
+      router.push(`/contents/${nextMedia.mediaId}?type=SERIES`);
+    } else {
+      await watchHistoryApi(nextMedia.mediaId).catch(() => {});
+      router.push(`/player/${nextMedia.mediaId}`);
+    }
   }, [nextMedia, router, setQueue]);
 
   usePlayback({

--- a/src/features/player/components/VideoPlayer.tsx
+++ b/src/features/player/components/VideoPlayer.tsx
@@ -20,7 +20,7 @@ import {
   VolumeX,
 } from "lucide-react";
 import { AutoPlayNextBanner, SettingModal } from "@features/player/components";
-import { playbackApi } from "@entities/player/api";
+import { playbackApi, watchHistoryApi } from "@entities/player/api";
 import { useHideControls, useHls, usePlayback } from "@entities/player/hooks";
 import { useContentsDetail } from "@entities/video-contents/hooks";
 import { useOutsideClick } from "@shared/hooks";
@@ -356,13 +356,14 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
     router.back();
   };
 
-  const handleNextConfirm = useCallback(() => {
+  const handleNextConfirm = useCallback(async () => {
     if (!nextMedia) return;
     showNextBannerRef.current = false;
     setShowNextBanner(false);
     isSavedRef.current = true;
     const { queue, source } = useAutoPlayStore.getState();
     setQueue(queue, nextMedia.mediaId, source ?? undefined);
+    await watchHistoryApi(nextMedia.mediaId).catch(() => {}); // 자동재생 이후 시청이력 갱신
     router.push(`/player/${nextMedia.mediaId}`);
   }, [nextMedia, router, setQueue]);
 

--- a/src/features/player/components/VideoPlayer.tsx
+++ b/src/features/player/components/VideoPlayer.tsx
@@ -72,7 +72,7 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
     isPip,
     currentTime: pipCurrentTime,
   } = usePipStore();
-  const { setQueue } = useAutoPlayStore();
+  const { setQueue, source } = useAutoPlayStore();
 
   // 다음 재생 영상 호출
   const nextMedia = useAutoPlayStore((state) => {
@@ -315,12 +315,32 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
   };
 
   const handleBack = async () => {
+    console.log("source:", source);
+    console.log("data:", data);
     isSavedRef.current = true;
     if (videoRef.current && !videoRef.current.paused) {
       videoRef.current.pause();
     }
     await playbackApi(mediaId, currentTimeRef.current).catch(() => {});
-    router.back();
+
+    if (data?.seriesMediaId) {
+      router.push(
+        `/contents/${data.seriesMediaId}/episode/${mediaId}?type=SERIES`,
+      );
+    } else if (source) {
+      // 단편인 경우 뒤에 playlist 를 쿼리스트링에 붙여서 router 이동
+      const params = new URLSearchParams({
+        type: "CONTENTS",
+        playlist: source.type,
+      });
+      if (source.type === "topTag" && "index" in source) {
+        params.set("index", String(source.index));
+      } // topTag 플리인 경우, index도 붙여서 이동
+      console.log("이동 URL:", `/contents/${mediaId}?${params.toString()}`);
+      router.push(`/contents/${mediaId}?${params.toString()}`);
+    } else {
+      router.push(`/contents/${mediaId}?type=CONTENTS`);
+    }
   };
 
   // pip
@@ -341,7 +361,8 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
     showNextBannerRef.current = false;
     setShowNextBanner(false);
     isSavedRef.current = true;
-    setQueue(useAutoPlayStore.getState().queue, nextMedia.mediaId);
+    const { queue, source } = useAutoPlayStore.getState();
+    setQueue(queue, nextMedia.mediaId, source ?? undefined);
     router.push(`/player/${nextMedia.mediaId}`);
   }, [nextMedia, router, setQueue]);
 

--- a/src/features/player/components/VideoPlayer.tsx
+++ b/src/features/player/components/VideoPlayer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { usePipStore } from "@store";
 import type { Level } from "hls.js";
 import {
@@ -21,8 +21,10 @@ import {
 } from "lucide-react";
 import { SettingModal } from "@features/player/components";
 import { useHideControls, useHls } from "@entities/player/hooks";
+import { usePlayback } from "@entities/player/hooks";
 import { useContentsDetail } from "@entities/video-contents/hooks";
 import { useOutsideClick } from "@shared/hooks";
+import { playbackApi } from "@/entities/player/api";
 
 interface VideoPlayerProps {
   mediaId: number;
@@ -36,6 +38,8 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const levelModalRef = useRef<HTMLDivElement>(null); // 화질 모달
   const speedModalRef = useRef<HTMLDivElement>(null); // 배속 모달
+  const currentTimeRef = useRef(0);
+  const isSavedRef = useRef(false);
 
   // 화질 선택 관련 state
   const [isOpenLevels, setIsOpenLevels] = useState<boolean>(false);
@@ -64,15 +68,47 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
     isPip,
     currentTime: pipCurrentTime,
   } = usePipStore();
+  const startTime = isPip ? pipCurrentTime : (data?.positionSec ?? 0);
 
-  const initialResumeTimeRef = useRef(isPip ? pipCurrentTime : 0);
+  const handleTimeUpdate = useCallback(() => {
+    if (videoRef.current) {
+      setCurrentTime(videoRef.current.currentTime);
+      currentTimeRef.current = videoRef.current.currentTime;
+    }
+  }, []);
+
+  const handleLoadedMetadata = useCallback(() => {
+    if (videoRef.current) {
+      setDuration(videoRef.current.duration);
+      videoRef.current.play().catch(() => {});
+    }
+  }, []);
+
+  const handlePlay = useCallback(() => setIsPlaying(true), []);
+  const handlePause = useCallback(() => setIsPlaying(false), []);
+
+  const attachVideoEvents = () => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    video.removeEventListener("timeupdate", handleTimeUpdate);
+    video.removeEventListener("loadedmetadata", handleLoadedMetadata);
+    video.removeEventListener("play", handlePlay);
+    video.removeEventListener("pause", handlePause);
+
+    video.addEventListener("timeupdate", handleTimeUpdate);
+    video.addEventListener("loadedmetadata", handleLoadedMetadata);
+    video.addEventListener("play", handlePlay);
+    video.addEventListener("pause", handlePause);
+  };
 
   // hls
   const hlsRef = useHls({
     src: data?.masterPlaylistUrl ?? "",
     videoRef,
     onLevels: setLevels,
-    startTime: initialResumeTimeRef.current,
+    startTime,
+    onReady: attachVideoEvents,
   });
 
   useEffect(() => {
@@ -99,11 +135,6 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
     { label: "1.25x", value: 1.25, isActive: playbackRate === 1.25 },
   ];
 
-  // 마우스 움직임 감지
-  const handleMouseMove = () => {
-    resetHideControlsTimer();
-  };
-
   useEffect(() => {
     containerRef.current?.focus();
   }, []);
@@ -117,40 +148,6 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
     document.addEventListener("fullscreenchange", handleFullscreenChange);
     return () => {
       document.removeEventListener("fullscreenchange", handleFullscreenChange);
-    };
-  }, []);
-
-  // 이벤트 핸들러들
-  const handleTimeUpdate = () => {
-    if (videoRef.current) {
-      setCurrentTime(videoRef.current.currentTime);
-    }
-  };
-
-  const handleLoadedMetadata = () => {
-    if (videoRef.current) {
-      setDuration(videoRef.current.duration);
-    }
-  };
-
-  const handlePlay = () => setIsPlaying(true);
-  const handlePause = () => setIsPlaying(false);
-
-  // video 이벤트 연결
-  useEffect(() => {
-    const video = videoRef.current;
-    if (!video) return;
-
-    video.addEventListener("timeupdate", handleTimeUpdate);
-    video.addEventListener("loadedmetadata", handleLoadedMetadata);
-    video.addEventListener("play", handlePlay);
-    video.addEventListener("pause", handlePause);
-
-    return () => {
-      video.removeEventListener("timeupdate", handleTimeUpdate);
-      video.removeEventListener("loadedmetadata", handleLoadedMetadata);
-      video.removeEventListener("play", handlePlay);
-      video.removeEventListener("pause", handlePause);
     };
   }, []);
 
@@ -271,30 +268,22 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
 
   // 키보드 단축키 핸들러
   const handleKeyboardShortcuts = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    // 스페이스바: 재생/일시정지
     if (e.code === "Space") {
       e.preventDefault();
       togglePlay();
     }
-
-    // 왼쪽 화살표: 10초 뒤로
     if (e.code === "ArrowLeft") {
       e.preventDefault();
       rewind();
     }
-
-    // 오른쪽 화살표: 10초 앞으로
     if (e.code === "ArrowRight") {
       e.preventDefault();
       forward();
     }
-
-    // 위쪽 화살표: 볼륨 올리기
     if (e.code === "ArrowUp") {
       e.preventDefault();
       adjustVolume(volume + 0.1);
     }
-    // 아래쪽 화살표: 볼륨 줄이기
     if (e.code === "ArrowDown") {
       e.preventDefault();
       adjustVolume(volume - 0.1);
@@ -302,10 +291,12 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
   };
 
   // 뒤로 가기
-  const handleBack = () => {
+  const handleBack = async () => {
+    isSavedRef.current = true;
     if (videoRef.current && !videoRef.current.paused) {
       videoRef.current.pause();
     }
+    await playbackApi(mediaId, currentTimeRef.current).catch(() => {});
     router.back();
   };
 
@@ -315,14 +306,27 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
     if (!video || !data?.masterPlaylistUrl) {
       return alert("pip 전환 중 에러가 발생했습니다. 다시 시도해주세요.");
     }
+    isSavedRef.current = true;
     video.pause();
-    enterPip(
-      data?.masterPlaylistUrl,
-      mediaId,
-      video.currentTime, // 현재 재생 시점 저장
-    );
+    await playbackApi(mediaId, video.currentTime).catch(() => {});
+    enterPip(data?.masterPlaylistUrl, mediaId, video.currentTime);
     router.back();
   };
+
+  // 이어보기 api
+  usePlayback({
+    mediaId,
+    getCurrentPostionSec: () => videoRef.current?.currentTime ?? 0,
+    isPlaying,
+  });
+
+  // 플레이어 unmount 시 playback 저장 (+ 트랙패드 뒤로가기 포함)
+  useEffect(() => {
+    return () => {
+      if (isSavedRef.current) return;
+      playbackApi(mediaId, currentTimeRef.current).catch(() => {});
+    };
+  }, [mediaId]);
 
   if (isLoading) return <div className="fixed inset-0 bg-black" />;
   return (

--- a/src/features/player/components/VideoPlayer.tsx
+++ b/src/features/player/components/VideoPlayer.tsx
@@ -324,6 +324,7 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
   useEffect(() => {
     return () => {
       if (isSavedRef.current) return;
+      if (currentTimeRef.current === 0) return;
       playbackApi(mediaId, currentTimeRef.current).catch(() => {});
     };
   }, [mediaId]);

--- a/src/features/player/components/VideoPlayer.tsx
+++ b/src/features/player/components/VideoPlayer.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { usePipStore } from "@store";
+import { useAutoPlayStore, usePipStore } from "@store";
 import type { Level } from "hls.js";
 import {
   ArrowLeft,
@@ -19,12 +19,13 @@ import {
   Volume2,
   VolumeX,
 } from "lucide-react";
-import { SettingModal } from "@features/player/components";
-import { useHideControls, useHls } from "@entities/player/hooks";
-import { usePlayback } from "@entities/player/hooks";
+import { AutoPlayNextBanner, SettingModal } from "@features/player/components";
+import { playbackApi } from "@entities/player/api";
+import { useHideControls, useHls, usePlayback } from "@entities/player/hooks";
 import { useContentsDetail } from "@entities/video-contents/hooks";
 import { useOutsideClick } from "@shared/hooks";
-import { playbackApi } from "@/entities/player/api";
+
+export const AUTO_PLAY_THRESHOLD = 0.95; // 영상길이 대 현재재생길이에 대한 비율 상수
 
 interface VideoPlayerProps {
   mediaId: number;
@@ -60,7 +61,10 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
   const [currentTime, setCurrentTime] = useState<number>(0); // 현재 시간
   const [duration, setDuration] = useState<number>(0); // 영상 길이
 
-  const [isFullscreen, setIsFullscreen] = useState<boolean>(false); // 전체화면 상태
+  const [isFullscreen, setIsFullscreen] = useState<boolean>(false);
+
+  const [showNextBanner, setShowNextBanner] = useState<boolean>(false);
+  const showNextBannerRef = useRef(false);
 
   const {
     enterPip,
@@ -68,12 +72,32 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
     isPip,
     currentTime: pipCurrentTime,
   } = usePipStore();
+  const { setQueue } = useAutoPlayStore();
+
+  // 다음 재생 영상 호출
+  const nextMedia = useAutoPlayStore((state) => {
+    const idx = state.queue.findIndex(
+      (item) => item.mediaId === state.currentMediaId,
+    );
+    return state.queue[idx + 1] ?? null;
+  });
+
   const startTime = isPip ? pipCurrentTime : (data?.positionSec ?? 0);
 
   const handleTimeUpdate = useCallback(() => {
     if (videoRef.current) {
       setCurrentTime(videoRef.current.currentTime);
       currentTimeRef.current = videoRef.current.currentTime;
+
+      const { currentTime, duration } = videoRef.current;
+      if (
+        duration > 0 &&
+        currentTime / duration >= AUTO_PLAY_THRESHOLD &&
+        !showNextBannerRef.current
+      ) {
+        showNextBannerRef.current = true;
+        setShowNextBanner(true);
+      }
     }
   }, []);
 
@@ -290,7 +314,6 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
     }
   };
 
-  // 뒤로 가기
   const handleBack = async () => {
     isSavedRef.current = true;
     if (videoRef.current && !videoRef.current.paused) {
@@ -313,7 +336,15 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
     router.back();
   };
 
-  // 이어보기 api
+  const handleNextConfirm = useCallback(() => {
+    if (!nextMedia) return;
+    showNextBannerRef.current = false;
+    setShowNextBanner(false);
+    isSavedRef.current = true;
+    setQueue(useAutoPlayStore.getState().queue, nextMedia.mediaId);
+    router.push(`/player/${nextMedia.mediaId}`);
+  }, [nextMedia, router, setQueue]);
+
   usePlayback({
     mediaId,
     getCurrentPostionSec: () => videoRef.current?.currentTime ?? 0,
@@ -330,6 +361,7 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
   }, [mediaId]);
 
   if (isLoading) return <div className="fixed inset-0 bg-black" />;
+
   return (
     <div
       ref={containerRef}
@@ -354,7 +386,6 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
         </button>
       </div>
 
-      {/* 비디오 영역 */}
       <div className="fixed inset-0 flex items-center justify-center">
         <div className="relative flex h-full max-h-screen w-full max-w-screen items-center justify-center">
           <video
@@ -366,11 +397,22 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
         </div>
       </div>
 
-      {/* 컨트롤러 */}
+      {showNextBanner && nextMedia && (
+        <AutoPlayNextBanner
+          type={data?.seriesMediaId ? "episode" : "contents"}
+          nextMedia={nextMedia}
+          onConfirm={handleNextConfirm}
+          onCancel={() => {
+            showNextBannerRef.current = false;
+            setShowNextBanner(false);
+          }}
+          showControls={showControls}
+        />
+      )}
+
       <div
         className={`text-ot-text fixed right-0 bottom-0 left-0 z-10 bg-linear-to-t from-black/40 via-black/20 to-transparent p-3 transition-opacity duration-300 ${showControls ? "opacity-100" : "opacity-0"}`}
       >
-        {/* Seek bar */}
         <div className="flex items-center gap-3">
           <p className="min-w-13 text-right text-sm whitespace-nowrap">
             {formatTime(currentTime)}
@@ -387,9 +429,7 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
             {formatTime(duration)}
           </p>
         </div>
-        {/* 컨트롤 버튼들 */}
         <div className="mt-2 flex justify-between px-2">
-          {/* 좌측: 재생, 감기, 음향 */}
           <div className="flex items-center gap-5">
             <button onClick={togglePlay}>
               {isPlaying ? (
@@ -405,7 +445,6 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
               <FastForward className="stroke-ot-text hover:stroke-ot-gray-600 h-8 w-8 cursor-pointer stroke-1" />
             </button>
 
-            {/* 음향 조절 */}
             <div className="group relative flex items-center">
               <div className="bg-ot-gray-800 invisible absolute bottom-full left-1/2 mb-2 -translate-x-1/2 flex-col items-center rounded-lg p-3 opacity-0 transition-all duration-200 group-hover:visible group-hover:opacity-100">
                 <input
@@ -435,9 +474,7 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
             </div>
           </div>
 
-          {/* 우측: 화질, 배속, 전체화면 */}
           <div className="flex items-center gap-5">
-            {/* 화질 */}
             <div ref={levelModalRef} className="relative flex items-center">
               <button
                 onClick={() => {
@@ -456,7 +493,6 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
               />
             </div>
 
-            {/* 배속 */}
             <div ref={speedModalRef} className="relative flex items-center">
               <button
                 onClick={() => {
@@ -476,7 +512,6 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
               />
             </div>
 
-            {/* 전체화면 */}
             <button onClick={toggleFullscreen}>
               {isFullscreen ? (
                 <Minimize className="stroke-ot-text hover:stroke-ot-gray-600 h-8 w-8 cursor-pointer stroke-1" />

--- a/src/features/player/components/index.ts
+++ b/src/features/player/components/index.ts
@@ -1,3 +1,4 @@
 export { VideoPlayer } from "./VideoPlayer";
 export { SettingModal } from "./SettingModal";
 export { FloatingPlayer } from "./FloatingPlayer";
+export { AutoPlayNextBanner } from "./AutoPlayNextBanner";

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -15,8 +15,25 @@ export function proxy(request: NextRequest) {
     return NextResponse.next();
   }
 
+  // FIXME: pr시에는 이걸 사용
+  // if (isDev) {
+  //   return NextResponse.next();
+  // }
+
   if (isDev) {
-    return NextResponse.next();
+    const response = NextResponse.next();
+
+    const keyPairId = process.env.CLOUDFRONT_KEY_PAIR_ID;
+    const policy = process.env.CLOUDFRONT_POLICY;
+    const signature = process.env.CLOUDFRONT_SIGNATURE;
+
+    if (keyPairId && policy && signature) {
+      response.cookies.set("CloudFront-Key-Pair-Id", keyPairId, { path: "/" });
+      response.cookies.set("CloudFront-Policy", policy, { path: "/" });
+      response.cookies.set("CloudFront-Signature", signature, { path: "/" });
+    }
+
+    return response;
   }
 
   const accessToken = request.cookies.get("accessToken")?.value;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -15,26 +15,27 @@ export function proxy(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // FIXME: pr시에는 이걸 사용
-  // if (isDev) {
-  //   return NextResponse.next();
-  // }
-
   if (isDev) {
-    const response = NextResponse.next();
-
-    const keyPairId = process.env.CLOUDFRONT_KEY_PAIR_ID;
-    const policy = process.env.CLOUDFRONT_POLICY;
-    const signature = process.env.CLOUDFRONT_SIGNATURE;
-
-    if (keyPairId && policy && signature) {
-      response.cookies.set("CloudFront-Key-Pair-Id", keyPairId, { path: "/" });
-      response.cookies.set("CloudFront-Policy", policy, { path: "/" });
-      response.cookies.set("CloudFront-Signature", signature, { path: "/" });
-    }
-
-    return response;
+    return NextResponse.next();
   }
+
+  // FIXME: 마지막에 주석 지우기!!
+  // FIXME: 개발환경에서 영상 play 해보고 싶다면 아래 주석 살린 뒤, cookie에 저장된 3개의 CloudFront Cookies -> .env.local에 저장해서 서버 재실행 -> s3에 업로드 되어 있는 영상 확인 가능
+  // if (isDev) {
+  //   const response = NextResponse.next();
+
+  //   const keyPairId = process.env.CLOUDFRONT_KEY_PAIR_ID;
+  //   const policy = process.env.CLOUDFRONT_POLICY;
+  //   const signature = process.env.CLOUDFRONT_SIGNATURE;
+
+  //   if (keyPairId && policy && signature) {
+  //     response.cookies.set("CloudFront-Key-Pair-Id", keyPairId, { path: "/" });
+  //     response.cookies.set("CloudFront-Policy", policy, { path: "/" });
+  //     response.cookies.set("CloudFront-Signature", signature, { path: "/" });
+  //   }
+
+  //   return response;
+  // }
 
   const accessToken = request.cookies.get("accessToken")?.value;
   const refreshToken = request.cookies.get("refreshToken")?.value;

--- a/src/store/autoPlayStore.ts
+++ b/src/store/autoPlayStore.ts
@@ -35,7 +35,8 @@ export const useAutoPlayStore = create<AutoPlayStore>()(
         return queue[idx + 1] ?? null;
       },
 
-      clear: () => set({ queue: [], currentMediaId: null }, false, "clear"),
+      clear: () =>
+        set({ queue: [], currentMediaId: null, source: null }, false, "clear"),
     }),
     { name: "AutoPlayStore", store: "AutoPlayStore", enabled: true },
   ),

--- a/src/store/autoPlayStore.ts
+++ b/src/store/autoPlayStore.ts
@@ -1,11 +1,12 @@
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
-import { PlaylistSource } from "@shared/types";
+import { MediaType, PlaylistSource } from "@shared/types";
 
 interface AutoPlayMedia {
   mediaId: number;
   title: string;
   thumbnailUrl: string;
+  mediaType: MediaType;
 }
 
 interface AutoPlayStore {

--- a/src/store/autoPlayStore.ts
+++ b/src/store/autoPlayStore.ts
@@ -35,6 +35,7 @@ export const useAutoPlayStore = create<AutoPlayStore>()(
       getNextMedia: () => {
         const { queue, currentMediaId } = get();
         const idx = queue.findIndex((item) => item.mediaId === currentMediaId);
+        if (idx < 0) return null;
         return queue[idx + 1] ?? null;
       },
 

--- a/src/store/autoPlayStore.ts
+++ b/src/store/autoPlayStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
+import { PlaylistSource } from "@shared/types";
 
 interface AutoPlayMedia {
   mediaId: number;
@@ -10,11 +11,11 @@ interface AutoPlayMedia {
 interface AutoPlayStore {
   queue: AutoPlayMedia[];
   currentMediaId: number | null;
-  source: string | null; // playlist 종류 들어옴
+  source: PlaylistSource | null; // playlist 종류 들어옴
   setQueue: (
     queue: AutoPlayMedia[],
     currentMediaId: number,
-    source?: string,
+    source?: PlaylistSource,
   ) => void; // 현재 저장되어있는 콘텐츠 리스트와 mediaId 저장
   getNextMedia: () => AutoPlayMedia | null;
   clear: () => void;
@@ -25,6 +26,7 @@ export const useAutoPlayStore = create<AutoPlayStore>()(
     (set, get) => ({
       queue: [],
       currentMediaId: null,
+      source: null,
 
       setQueue: (queue, currentMediaId, source) =>
         set({ queue, currentMediaId, source }, false, "setQueue"),

--- a/src/store/autoPlayStore.ts
+++ b/src/store/autoPlayStore.ts
@@ -1,0 +1,42 @@
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+
+interface AutoPlayMedia {
+  mediaId: number;
+  title: string;
+  thumbnailUrl: string;
+}
+
+interface AutoPlayStore {
+  queue: AutoPlayMedia[];
+  currentMediaId: number | null;
+  source: string | null; // playlist 종류 들어옴
+  setQueue: (
+    queue: AutoPlayMedia[],
+    currentMediaId: number,
+    source?: string,
+  ) => void; // 현재 저장되어있는 콘텐츠 리스트와 mediaId 저장
+  getNextMedia: () => AutoPlayMedia | null;
+  clear: () => void;
+}
+
+export const useAutoPlayStore = create<AutoPlayStore>()(
+  devtools(
+    (set, get) => ({
+      queue: [],
+      currentMediaId: null,
+
+      setQueue: (queue, currentMediaId, source) =>
+        set({ queue, currentMediaId, source }, false, "setQueue"),
+
+      getNextMedia: () => {
+        const { queue, currentMediaId } = get();
+        const idx = queue.findIndex((item) => item.mediaId === currentMediaId);
+        return queue[idx + 1] ?? null;
+      },
+
+      clear: () => set({ queue: [], currentMediaId: null }, false, "clear"),
+    }),
+    { name: "AutoPlayStore", store: "AutoPlayStore", enabled: true },
+  ),
+);

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,1 +1,2 @@
 export { usePipStore } from "./pipStore";
+export { useAutoPlayStore } from "./autoPlayStore";

--- a/src/store/pipStore.ts
+++ b/src/store/pipStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { devtools } from "zustand/middleware";
 
 interface PipState {
   isPip: boolean;
@@ -10,14 +11,20 @@ interface PipState {
   setCurrentTime: (time: number) => void;
 }
 
-export const usePipStore = create<PipState>((set) => ({
-  isPip: false,
-  src: "",
-  mediaId: null,
-  currentTime: 0,
-  enterPip: (src, mediaId, currentTime) => {
-    set({ isPip: true, src, mediaId, currentTime });
-  },
-  exitPip: () => set({ isPip: false, src: "", mediaId: null }),
-  setCurrentTime: (time) => set({ currentTime: time }),
-}));
+export const usePipStore = create<PipState>()(
+  devtools(
+    (set) => ({
+      isPip: false,
+      src: "",
+      mediaId: null,
+      currentTime: 0,
+      enterPip: (src, mediaId, currentTime) =>
+        set({ isPip: true, src, mediaId, currentTime }, false, "enterPip"),
+      exitPip: () =>
+        set({ isPip: false, src: "", mediaId: null }, false, "exitPip"),
+      setCurrentTime: (time) =>
+        set({ currentTime: time }, false, "setCurrentTime"),
+    }),
+    { name: "PipStore" },
+  ),
+);


### PR DESCRIPTION
## 📝 작업 내용

> **구현**
>
> - 시청이력 갱신/생성 API 및 연동 (`/watch-history`)
> - `playback` API 구현 및 hooks 구현, 연동 (10초마다 `playback` 호출해서 현재 영상 위치를 서버에 전송합니다. )
> - 재생 버튼 클릭 시 시청이력 API 연동 (watch-history)
>      - 시청이력 갱신 시, resumeMediaId가 갱신되면서 시리즈 원본 페이지에서 '재생하기' 버튼을 누르면 최근 시청 에피소드(resumeMediaId) 페이지로 이동하는 구조입니다.
> - pipStore Redux DevTools 연동
>
> - 자동재생 playlist store 구현 (zustand + devtools)
>     - 자동재생 시, playlist를 zustand에 저장해서 연속재생 시 해당 playlist의 다음 콘텐츠로 이동하는 구조입니다.
>     - 상태저장이 되어있는 것을 확인하기 위해 Redux devTools 을 추가하여 확인하였습니다.
>
> - 자동/연속재생 기능 구현 (95% 도달 시 배너 표시, 카운트다운 후 전환)
>    - 시리즈의 경우, 5초 후 다음 에피소드 재생
>    - 단편의 경우, 15초 후 다음 콘텐츠 재생
>        - 단편 -> 시리즈로 넘어가는 경우, 시리즈 원본 상세 페이지로 넘어갑니다.
>    - playlist의 마지막 콘텐츠인 경우, 자동재생 배너가 나타나지 않습니다.
> - 자동재생 시 해당 영상 시청이력 갱신
> - 플레이어 뒤로가기 시 현재 mediaId의 상세페이지 이동 (playlist 유지 -> 만약 recommend가 playlist인 경우, recommend를 쿼리스트링에 붙이고 이동)
>
> **버그픽스**
>
> - 플레이어 새로고침 시 seek bar 작동 안하는 문제 해결
> - 플레이어 unmount 시 playback 저장 안정화 

### 📷 스크린샷
- playback 10초마다 호출

https://github.com/user-attachments/assets/312ffe43-b7bd-43fc-bf64-5cfb739a581c

- 시리즈 자동재생

https://github.com/user-attachments/assets/e6853f37-7445-43e6-ad0b-ea3aca7af0fd

- 시리즈 재생하기 클릭 시, 최근 시청한 에피소드로 이동

https://github.com/user-attachments/assets/ca0576f5-8314-4e40-af8c-cd671c43ea03

- 단편 연속 재생

https://github.com/user-attachments/assets/e143d987-89fd-4a03-94f7-56226349418e

- playlist 안에 단편 다음 시리즈인 경우, 시리즈 원본 페이지로 이동

https://github.com/user-attachments/assets/a6f782de-dfb4-4ccf-86a8-5c65245f1a3d


- 뒤로가기 버튼 -> 현재 mediaId의 페이지로 이동

https://github.com/user-attachments/assets/72adbabd-7fa4-422d-ac24-3e67729aee43





## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

`VideoPlayer`

- handleTimeUpdate는 현재 재생 위치를 추적하고, 재생 위치가 총 영상 길이의 95% 도달 시 자동재생 배너를 띄우는 로직입니다.

```ts
  const handleTimeUpdate = useCallback(() => {
    if (videoRef.current) {
      setCurrentTime(videoRef.current.currentTime);
      currentTimeRef.current = videoRef.current.currentTime;

      const { currentTime, duration } = videoRef.current;
      if (
        duration > 0 &&
        currentTime / duration >= AUTO_PLAY_THRESHOLD &&
        !showNextBannerRef.current
      ) {
        showNextBannerRef.current = true;
        setShowNextBanner(true);
      }
    }
  }, []);
```


`VideoPlayer`

- zustand에 저장된 플레이리스트의 다음 항목을 재생합니다.

```ts
  const { setQueue, source } = useAutoPlayStore();

  // 다음 재생 영상 호출
  const nextMedia = useAutoPlayStore((state) => {
    const idx = state.queue.findIndex(
      (item) => item.mediaId === state.currentMediaId,
    );
    return state.queue[idx + 1] ?? null;
  });

```


`VideoPlayer`

- 뒤로가기 버튼 클릭 시, 현재 mediaId 기준으로 상세페이지로 이동하는 로직입니다. 기존에는 router.back()을 사용했으나, 자동재생을 하게 되면 뒤로가기를 누를 때 이전 플레이어로 계속 넘어가는 구조였어서 UX 개선을 위해 이렇게 구현했습니다.
- 이때 뒤로갈때는 zustand에 담겨있는 playlist가 있다면, playlist 쿼리스트링도 유지해서 이동합니다. 

```ts

  // 뒤로가기
  const handleBack = async () => {
    isSavedRef.current = true;
    if (videoRef.current && !videoRef.current.paused) {
      videoRef.current.pause();
    }
    await playbackApi(mediaId, currentTimeRef.current).catch(() => {});

    if (data?.seriesMediaId) {
      router.push(
        `/contents/${data.seriesMediaId}/episode/${mediaId}?type=SERIES`,
      );
    } else if (source) {
      // 단편인 경우 뒤에 playlist 를 쿼리스트링에 붙여서 router 이동
      const params = new URLSearchParams({
        type: "CONTENTS",
        playlist: source.type,
      });
      if (source.type === "topTag" && "index" in source) {
        params.set("index", String(source.index));
      } // topTag 플리인 경우, index도 붙여서 이동
      router.push(`/contents/${mediaId}?${params.toString()}`);
    } else {
      router.push(`/contents/${mediaId}?type=CONTENTS`);
    }
  };

```

`VideoPlayer의 handleNextConfirm()`

- 자동재생 배너에서 다음 영상으로 전환하는 핸들러 함수입니다. (길어서 설명으로 작성)
```
- nextMedia.mediaType이 SERIES면 시리즈 상세페이지로 이동
- CONTENTS면 시청이력 갱신 후 플레이어로 이동
- source를 유지해서 setQueue 재호출로 playlist 컨텍스트 보존
- usePlayback으로 10초마다 현재 재생 위치 서버에 저장
- unmount 시 마지막 재생 위치 저장 (트랙패드 뒤로가기 포함)
```

## ☑️ 체크 리스트

> 체크 리스트를 확인해주세요

- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?

## #️⃣ 연관된 이슈

> ex) #128 

## 💬 리뷰 요구사항

> https://www.notion.so/24-3232753972b780718ab4d27f968cfc68?source=copy_link
>
> 관련 로직은 정리해서 노션에 정리해 두었습니다. 흐름상 이해 안가거나 UX적으로 어색한 부분이 있다면 말해주세요! 현재 db에 있는 영상이 1개라서 자동재생을 해도 같은 재생위치가 유지되는 것은 어쩔 수 없는 부분이라 양해해서 봐주시면 될 것 같습니다. (아마 실제 다른 값이 들어오면 유지되지 않을 것이라 생각됩니다.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 다음 콘텐츠 자동 재생 배너(카운트다운) 추가
  * 자동 재생 큐 및 관련 제어 추가
  * 재생 중 주기적 재생 위치 전송 기능 추가

* **개선 사항**
  * 재생 시 시청 기록 자동 저장 처리 추가
  * 추천 회전판 링크 생성 방식 및 UI 정렬 소소 개선
  * 재생 상태 관리와 플레이리스트 큐 동작 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->