### PR TITLE
[OT-326][FIX]: 마이페이지 QA 반영 수정

### DIFF
--- a/src/entities/profile/api/editprofile.ts
+++ b/src/entities/profile/api/editprofile.ts
@@ -1,5 +1,4 @@
 import { api } from "@shared/api";
-import { ApiResponse } from "@shared/types";
 import { MemberProfile } from "@/entities/profile/api";
 
 export interface UpdateMemberRequest {
@@ -7,6 +6,12 @@ export interface UpdateMemberRequest {
   tagIds: number[];
 }
 
+export interface EditProfileParams {
+  nickname: string;
+  tagIds: number[];
+}
+
 export const editProfileApi = {
-  updateMemberProfile: (body: UpdateMemberRequest) => api.patch<MemberProfile>("/member/me", body),
+  updateMemberProfile: (body: UpdateMemberRequest) =>
+    api.patch<MemberProfile>("/member/me", body),
 };

--- a/src/entities/profile/api/index.ts
+++ b/src/entities/profile/api/index.ts
@@ -1,4 +1,4 @@
 export { memberApi } from "./userinfo";
 export type { MemberProfile } from "./userinfo";
 export { editProfileApi } from "./editprofile";
-export type { UpdateMemberRequest } from "./editprofile";
+export type { UpdateMemberRequest, EditProfileParams } from "./editprofile";

--- a/src/entities/profile/hooks/index.ts
+++ b/src/entities/profile/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useMemberProfile } from "./useMemberProfile";
+export { useEditProfile } from "./useEditProfile";

--- a/src/entities/profile/hooks/useEditProfile.ts
+++ b/src/entities/profile/hooks/useEditProfile.ts
@@ -2,8 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { EditProfileParams } from "@entities/profile/api";
-import { editProfileApi } from "@/entities/profile/api";
+import { EditProfileParams, editProfileApi } from "@entities/profile/api";
 
 export function useEditProfile() {
   const router = useRouter();

--- a/src/entities/profile/hooks/useEditProfile.ts
+++ b/src/entities/profile/hooks/useEditProfile.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { EditProfileParams } from "@entities/profile/api";
+import { editProfileApi } from "@/entities/profile/api";
+
+export function useEditProfile() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: ({ nickname, tagIds }: EditProfileParams) =>
+      editProfileApi.updateMemberProfile({ nickname, tagIds }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["memberProfile"] });
+      router.push("/mypage");
+    },
+    onError: (err) => {
+      console.error("프로필 수정 실패:", err);
+    },
+  });
+
+  return { mutate, isPending };
+}

--- a/src/features/auth/components/Main/PosterBackground.tsx
+++ b/src/features/auth/components/Main/PosterBackground.tsx
@@ -2,7 +2,10 @@
 
 import Image from "next/image";
 
-const posters = Array.from({ length: 18 }, (_, i) => `/images/poster${i + 1}.jpg`);
+const posters = Array.from(
+  { length: 18 },
+  (_, i) => `/images/poster${i + 1}.jpg`,
+);
 
 // 3줄로 나누기 (각 줄 6개)
 const row1 = posters.slice(0, 6);
@@ -11,14 +14,14 @@ const row3 = posters.slice(12, 18);
 
 export function PosterBackground() {
   return (
-    <div className="absolute inset-0 overflow-hidden mix-blend-lighten">
-      <div className="absolute inset-0 flex flex-col gap-4 -rotate-12 scale-125 origin-center">
+    <div className="fixed inset-0 overflow-hidden mix-blend-lighten">
+      <div className="absolute inset-0 flex origin-center scale-125 -rotate-12 flex-col gap-4">
         {/* 행1 */}
         <div className="flex gap-4">
           {[...row1, ...row1].map((poster, index) => (
             <div
               key={`row1-${index}`}
-              className="relative w-40 h-60 shrink-0 rounded-lg overflow-hidden"
+              className="relative h-60 w-40 shrink-0 overflow-hidden rounded-lg"
             >
               <Image
                 src={poster}
@@ -32,11 +35,11 @@ export function PosterBackground() {
         </div>
 
         {/* 행2 */}
-        <div className="flex gap-4 -ml-20">
+        <div className="-ml-20 flex gap-4">
           {[...row2, ...row2].map((poster, index) => (
             <div
               key={`row2-${index}`}
-              className="relative w-40 h-60 shrink-0 rounded-lg overflow-hidden"
+              className="relative h-60 w-40 shrink-0 overflow-hidden rounded-lg"
             >
               <Image
                 src={poster}
@@ -54,7 +57,7 @@ export function PosterBackground() {
           {[...row3, ...row3].map((poster, index) => (
             <div
               key={`row3-${index}`}
-              className="relative w-40 h-60 shrink-0 rounded-lg overflow-hidden"
+              className="relative h-60 w-40 shrink-0 overflow-hidden rounded-lg"
             >
               <Image
                 src={poster}
@@ -69,8 +72,8 @@ export function PosterBackground() {
       </div>
 
       {/* 어두운 오버레이 그라데이션 */}
-      <div className="absolute inset-0 bg-linear-to-b from-ot-background/30 via-ot-background/40 to-ot-background/80" />
-      <div className="absolute inset-0 bg-linear-to-r from-ot-background/70 via-transparent to-ot-background/20" />
+      <div className="from-ot-background/30 via-ot-background/40 to-ot-background/80 absolute inset-0 bg-linear-to-b" />
+      <div className="from-ot-background/70 to-ot-background/20 absolute inset-0 bg-linear-to-r via-transparent" />
     </div>
   );
 }

--- a/src/features/dashboard/components/DashboardContentBox.tsx
+++ b/src/features/dashboard/components/DashboardContentBox.tsx
@@ -4,7 +4,7 @@ import { DashboardContentList } from "@features/dashboard/components";
 import { useTagRanking } from "@entities/dashboard/hooks/useTagRanking";
 import { DashboardData } from "@shared/types/mypage/dashboard";
 
-const COLORS = ["#9d0037", "#f10059", "#ff768f", "#ffa4b2", "#ffecef"];
+const COLORS = ["#55021a", "#9f0040", "#ff5474", "#ffa9b6", "#fffefe"];
 
 export default function DashboardContentBox() {
   const { data, isLoading, isError } = useTagRanking();

--- a/src/features/dashboard/components/DashboardContentBox.tsx
+++ b/src/features/dashboard/components/DashboardContentBox.tsx
@@ -4,7 +4,7 @@ import { DashboardContentList } from "@features/dashboard/components";
 import { useTagRanking } from "@entities/dashboard/hooks/useTagRanking";
 import { DashboardData } from "@shared/types/mypage/dashboard";
 
-const COLORS = ["#55021a", "#9f0040", "#ff5474", "#ffa9b6", "#fffefe"];
+const COLORS = ["#5f001b", "#9c003e", "#ff5f7c", "#ffd1d8", "#f2f2f2"];
 
 export default function DashboardContentBox() {
   const { data, isLoading, isError } = useTagRanking();

--- a/src/features/dashboard/components/DashboardContentList.tsx
+++ b/src/features/dashboard/components/DashboardContentList.tsx
@@ -2,12 +2,18 @@
 
 import { useState } from "react";
 import { Pie } from "react-chartjs-2";
-import { Chart as ChartJS, ArcElement, Tooltip, Legend, ChartOptions } from "chart.js";
+import {
+  ArcElement,
+  Chart as ChartJS,
+  ChartOptions,
+  Legend,
+  Tooltip,
+} from "chart.js";
 import ChartDataLabels from "chartjs-plugin-datalabels";
-import { DashboardData } from "@shared/types/mypage/dashboard";
 import { TagStatsModal } from "@features/dashboard/components";
 import { useTagMonthlyStats } from "@entities/dashboard/hooks";
 import { useTagRecommendPlaylist } from "@entities/dashboard/hooks";
+import { DashboardData } from "@shared/types/mypage/dashboard";
 
 ChartJS.register(ArcElement, Tooltip, Legend, ChartDataLabels);
 
@@ -15,12 +21,22 @@ interface DashboardContentListProps {
   data: DashboardData;
 }
 
-export default function DashboardContentList({ data }: DashboardContentListProps) {
+export default function DashboardContentList({
+  data,
+}: DashboardContentListProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedTag, setSelectedTag] = useState<{ name: string } | null>(null);
   const [selectedTagId, setSelectedTagId] = useState<number | null>(null);
-  const { data: monthlyStats, isLoading: isStatsLoading, isError: isStatsError } = useTagMonthlyStats(selectedTagId ?? 0);
-  const { data: playlist, isLoading: isPlaylistLoading, isError: isPlaylistError } = useTagRecommendPlaylist(selectedTagId ?? 0);
+  const {
+    data: monthlyStats,
+    isLoading: isStatsLoading,
+    isError: isStatsError,
+  } = useTagMonthlyStats(selectedTagId ?? 0);
+  const {
+    data: playlist,
+    isLoading: isPlaylistLoading,
+    isError: isPlaylistError,
+  } = useTagRecommendPlaylist(selectedTagId ?? 0);
 
   // 차트 스타일 & 동작 옵션
   const options: ChartOptions<"pie"> = {
@@ -68,7 +84,7 @@ export default function DashboardContentList({ data }: DashboardContentListProps
     elements: {
       arc: {
         borderWidth: 0,
-        hoverOffset: 20,
+        hoverOffset: 0,
       },
     },
     layout: {
@@ -108,7 +124,9 @@ export default function DashboardContentList({ data }: DashboardContentListProps
         },
         formatter: (value, context) => {
           const idx = context.dataIndex;
-          const label = context.chart.data.labels ? context.chart.data.labels[idx] : "-ui";
+          const label = context.chart.data.labels
+            ? context.chart.data.labels[idx]
+            : "-ui";
           return `${label} - ${value}번`;
         },
       },
@@ -116,7 +134,7 @@ export default function DashboardContentList({ data }: DashboardContentListProps
   };
 
   return (
-    <div className="w-full h-125 flex justify-center items-center">
+    <div className="flex h-125 w-full items-center justify-center">
       <Pie data={data} options={options} />
       {selectedTag && (
         <TagStatsModal
@@ -129,10 +147,12 @@ export default function DashboardContentList({ data }: DashboardContentListProps
             thisMonth: monthlyStats?.currentMonth.count ?? 0,
             lastMonth: monthlyStats?.previousMonth?.count ?? 0,
           }}
-          recommendations={playlist?.dataList.map((item) => ({
-            id: item.mediaId,
-            image: item.posterUrl,
-          })) ?? []} // 없으면 빈 칸
+          recommendations={
+            playlist?.dataList.map((item) => ({
+              id: item.mediaId,
+              image: item.posterUrl,
+            })) ?? []
+          } // 없으면 빈 칸
         />
       )}
     </div>

--- a/src/features/dashboard/components/DashboardContentList.tsx
+++ b/src/features/dashboard/components/DashboardContentList.tsx
@@ -91,8 +91,8 @@ export default function DashboardContentList({
       padding: {
         top: 60,
         bottom: 60,
-        left: 300,
-        right: 200,
+        left: 150, // 300 -> 120
+        right: 50, // 200 -> 80
       },
     },
     plugins: {
@@ -134,7 +134,7 @@ export default function DashboardContentList({
   };
 
   return (
-    <div className="flex h-125 w-full items-center justify-center">
+    <div className="flex h-125 w-full min-w-150 items-center justify-center overflow-x-auto">
       <Pie data={data} options={options} />
       {selectedTag && (
         <TagStatsModal

--- a/src/features/profile/components/EditFavoriteTagsUI.tsx
+++ b/src/features/profile/components/EditFavoriteTagsUI.tsx
@@ -1,22 +1,35 @@
 "use client";
 
-import { useEffect, useMemo, useState, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { getCategories, getTags, CategoryItem, TagItem } from "@entities/auth/api";
-import { ListCategory, SelectTag, SelectedTag } from "@features/auth/components/Interest";
-import { FinishEditButton } from "@features/profile/components";
+import {
+  ListCategory,
+  SelectTag,
+  SelectedTag,
+} from "@features/auth/components/Interest";
+import {
+  CategoryItem,
+  TagItem,
+  getCategories,
+  getTags,
+} from "@entities/auth/api";
 
 interface EditFavoriteTagsUIProps {
-  nickname: string;
   initialTagIds: number[];
+  onTagsChange: (tagIds: number[]) => void;
 }
 
-export default function EditFavoriteTagsUI({ nickname, initialTagIds }: EditFavoriteTagsUIProps) {
-  const [selectedCategory, setSelectedCategory] = useState<CategoryItem | null>(null);
+export default function EditFavoriteTagsUI({
+  initialTagIds,
+  onTagsChange,
+}: EditFavoriteTagsUIProps) {
+  const [selectedCategory, setSelectedCategory] = useState<CategoryItem | null>(
+    null,
+  );
   const hasInitializedRef = useRef(false);
 
   // 선택된 태그는 tagId 배열 하나만 관리
-  const [selectedTagIds, setSelectedTagIds] = useState<number[]>([]);
+  const [selectedTagIds, setSelectedTagIds] = useState<number[]>(initialTagIds);
 
   // 부모에서 내려준 초기 태그 세팅
   useEffect(() => {
@@ -52,14 +65,18 @@ export default function EditFavoriteTagsUI({ nickname, initialTagIds }: EditFavo
           })),
         ),
       ).then((results) =>
-        Object.fromEntries(results.map(({ categoryId, tags }) => [categoryId, tags])),
+        Object.fromEntries(
+          results.map(({ categoryId, tags }) => [categoryId, tags]),
+        ),
       ),
     enabled: categories.length > 0,
     staleTime: Infinity,
   });
 
   const currentTags = selectedCategory
-    ? ((tagsByCategory as Record<number, TagItem[]>)[selectedCategory.categoryId] ?? [])
+    ? ((tagsByCategory as Record<number, TagItem[]>)[
+        selectedCategory.categoryId
+      ] ?? [])
     : [];
 
   const handleToggleTag = (tagId: number) => {
@@ -68,13 +85,19 @@ export default function EditFavoriteTagsUI({ nickname, initialTagIds }: EditFavo
         alert("태그는 최대 5개까지만 선택할 수 있습니다.");
         return prev;
       }
-      return prev.includes(tagId) ? prev.filter((id) => id !== tagId) : [...prev, tagId];
+      return prev.includes(tagId)
+        ? prev.filter((id) => id !== tagId)
+        : [...prev, tagId];
     });
   };
 
   const handleClearAll = () => {
     setSelectedTagIds([]);
   };
+
+  useEffect(() => {
+    onTagsChange(selectedTagIds);
+  }, [selectedTagIds]);
 
   // 선택된 태그를 카테고리별로 UI에 표시
   const selectedTagsByCategory: Record<string, string[]> = useMemo(() => {
@@ -89,11 +112,11 @@ export default function EditFavoriteTagsUI({ nickname, initialTagIds }: EditFavo
   }, [categories, tagsByCategory, selectedTagIds]);
 
   return (
-    <section className="w-full bg-ot-background flex-1 flex flex-col items-center justify-center py-6">
-      <div className="px-3 max-w-275 mx-auto w-full flex flex-col items-center">
+    <section className="bg-ot-background flex w-full flex-1 flex-col items-center justify-center py-6">
+      <div className="mx-auto flex w-full max-w-275 flex-col items-center px-3">
         {/* 카테고리 & 태그 선택 */}
-        <div className="w-full flex border border-text-ot-text rounded-lg overflow-hidden mb-2">
-          <div className="border-r border-text-ot-text">
+        <div className="border-text-ot-text mb-2 flex w-full overflow-hidden rounded-lg border">
+          <div className="border-text-ot-text border-r">
             <ListCategory
               categories={categories}
               selectedCategory={selectedCategory}
@@ -115,9 +138,6 @@ export default function EditFavoriteTagsUI({ nickname, initialTagIds }: EditFavo
             onClearAll={handleClearAll}
           />
         </div>
-
-        {/* 저장 버튼 */}
-        <FinishEditButton nickname={nickname} selectedTagIds={selectedTagIds} />
       </div>
     </section>
   );

--- a/src/features/profile/components/FinishEditButton.tsx
+++ b/src/features/profile/components/FinishEditButton.tsx
@@ -1,40 +1,27 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { CommonButton } from "@base-components";
-import { editProfileApi } from "@/entities/profile/api";
+import { useEditProfile } from "@/entities/profile/hooks/useEditProfile";
 
 interface FinishEditButtonProps {
   nickname: string;
   selectedTagIds: number[];
+  disabled?: boolean;
 }
 
-export default function FinishEditButton({ nickname, selectedTagIds }: FinishEditButtonProps) {
-  const router = useRouter();
-  const queryClient = useQueryClient();
-
-  const { mutate, isPending } = useMutation({
-    mutationFn: () =>
-      editProfileApi.updateMemberProfile({
-        nickname,
-        tagIds: selectedTagIds,
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["memberProfile"] });
-      router.push("/mypage");
-    },
-    onError: (err) => {
-      console.error("프로필 수정 실패:", err);
-    },
-  });
+export default function FinishEditButton({
+  nickname,
+  selectedTagIds,
+  disabled,
+}: FinishEditButtonProps) {
+  const { mutate, isPending } = useEditProfile();
 
   return (
     <div>
       <CommonButton
-        onClick={() => mutate()}
-        disabled={isPending}
-        className="mt-4 mb-4 py-3 px-25 text-ot-text text-[18px] font-bold"
+        onClick={() => mutate({ nickname, tagIds: selectedTagIds })}
+        disabled={isPending || !!disabled}
+        className="text-ot-text mt-4 mb-4 px-25 py-3 text-[18px] font-bold"
       >
         수정하기
       </CommonButton>

--- a/src/features/profile/components/FinishEditButton.tsx
+++ b/src/features/profile/components/FinishEditButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { CommonButton } from "@base-components";
-import { useEditProfile } from "@/entities/profile/hooks/useEditProfile";
+import { useEditProfile } from "@/entities/profile/hooks";
 
 interface FinishEditButtonProps {
   nickname: string;
@@ -20,7 +20,7 @@ export default function FinishEditButton({
     <div className="flex justify-center">
       <CommonButton
         onClick={() => mutate({ nickname, tagIds: selectedTagIds })}
-        disabled={isPending || !!disabled}
+        disabled={isPending || disabled}
         className={`text-ot-text mt-4 mb-4 px-25 py-3 text-[18px] font-bold ${isPending || !!disabled ? "cursor-not-allowed opacity-50" : ""}`}
       >
         수정하기

--- a/src/features/profile/components/FinishEditButton.tsx
+++ b/src/features/profile/components/FinishEditButton.tsx
@@ -17,11 +17,11 @@ export default function FinishEditButton({
   const { mutate, isPending } = useEditProfile();
 
   return (
-    <div>
+    <div className="flex justify-center">
       <CommonButton
         onClick={() => mutate({ nickname, tagIds: selectedTagIds })}
         disabled={isPending || !!disabled}
-        className="text-ot-text mt-4 mb-4 px-25 py-3 text-[18px] font-bold"
+        className={`text-ot-text mt-4 mb-4 px-25 py-3 text-[18px] font-bold ${isPending || !!disabled ? "cursor-not-allowed opacity-50" : ""}`}
       >
         수정하기
       </CommonButton>

--- a/src/features/profile/components/ProfileEditContainer.tsx
+++ b/src/features/profile/components/ProfileEditContainer.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useState } from "react";
+import {
+  EditFavoriteTagsUI,
+  FinishEditButton,
+  ProfileEditor,
+} from "@features/profile/components";
 import { MemberProfile } from "@/entities/profile/api";
 import { useMemberProfile } from "@/entities/profile/hooks";
-import EditFavoriteTagsUI from "./EditFavoriteTagsUI";
-import FinishEditButton from "./FinishEditButton";
-import ProfileEditor from "./ProfileEditor";
 
 function ProfileEditContent({ profile }: { profile: MemberProfile }) {
   const initialTagIds = profile.preferredTags.map((t) => t.tagId);

--- a/src/features/profile/components/ProfileEditContainer.tsx
+++ b/src/features/profile/components/ProfileEditContainer.tsx
@@ -1,29 +1,45 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState } from "react";
+import { MemberProfile } from "@/entities/profile/api";
 import { useMemberProfile } from "@/entities/profile/hooks";
-import ProfileEditor from "./ProfileEditor";
 import EditFavoriteTagsUI from "./EditFavoriteTagsUI";
+import FinishEditButton from "./FinishEditButton";
+import ProfileEditor from "./ProfileEditor";
 
-export default function ProfileEditContainer() {
-  const { data: profile } = useMemberProfile();
-  const [nickname, setNickname] = useState<string>("");
-  const isInitializedRef = useRef(false);
+function ProfileEditContent({ profile }: { profile: MemberProfile }) {
+  const initialTagIds = profile.preferredTags.map((t) => t.tagId);
 
-  useEffect(() => {
-    if (profile && !isInitializedRef.current) {
-      setNickname(profile.nickname);
-      isInitializedRef.current = true;
-    }
-  }, [profile]);
+  const [nickname, setNickname] = useState<string>(profile.nickname);
+  const [selectedTagIds, setSelectedTagIds] = useState<number[]>(initialTagIds);
 
-  const preferredTagIds = profile?.preferredTags.map((t) => t.tagId) ?? [];
+  const isNicknameChanged = nickname !== profile.nickname;
+  const isTagsChanged =
+    selectedTagIds.length !== initialTagIds.length ||
+    selectedTagIds.some((id) => !initialTagIds.includes(id));
+
+  const isChanged = isNicknameChanged || isTagsChanged;
 
   return (
     <>
       <ProfileEditor nickname={nickname} onNicknameChange={setNickname} />
-
-      <EditFavoriteTagsUI nickname={nickname} initialTagIds={preferredTagIds} />
+      <EditFavoriteTagsUI
+        initialTagIds={initialTagIds}
+        onTagsChange={setSelectedTagIds}
+      />
+      <FinishEditButton
+        nickname={nickname}
+        selectedTagIds={selectedTagIds}
+        disabled={!isChanged}
+      />
     </>
   );
+}
+
+export default function ProfileEditContainer() {
+  const { data: profile } = useMemberProfile();
+
+  if (!profile) return null;
+
+  return <ProfileEditContent profile={profile} />;
 }


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 적어주세요

- [x] 온보딩 첫페이지 배경이미지 움직이는 문제 해결
- [x] 상세 통계 원그래프 반응형 & 색감 조절
- [x] 프로필 수정 페이지 수정하기 버튼 disable 기능 추가
 

### 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. src에 이미지 url만 등록하면 됩니다. -->

| 구현 내용 |             SE              |
| :-------: | :-------------------------: |
|    GIF    | <img src = "https://github.com/user-attachments/assets/16513f94-73ab-4b6a-8163-2760708631fb" width ="250"> |

상세 통계 원그래프 색감 조절

https://github.com/user-attachments/assets/68080a73-eb7a-4030-9c43-ff6ca623b632


프로필 수정 페이지 버튼 disable

https://github.com/user-attachments/assets/87ccf914-6711-4f0e-a1d0-f10a0d2db439


## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

- src\entities\profile\hooks\useEditProfile.ts : 기존 FinishEditButton.tsx에 있던 mutation 부분을 따로 구별하여 만들었습니다.

- src\features\profile\components\ProfileEditContainer.tsx : EsLint 에러로 안에 ProfileEditContent 추가하고 이를 호출하는 식으로 바꿨습니다.
```
function ProfileEditContent({ profile }: { profile: MemberProfile }) {
  ...
}
```

FinishEditButton 위치를 EditFavoriteTagsUI.tsx에서 ProfileEditContainer.tsx로 옮겼습니다.
```
import FinishEditButton from "./FinishEditButton";

...

<FinishEditButton
  nickname={nickname}
  selectedTagIds={selectedTagIds}
  disabled={!isChanged}
/>
...
```

## ☑️ 체크 리스트

> 체크 리스트를 확인해주세요

- [ ] 테스트는 잘 통과했나요?
- [ ] 충돌을 해결했나요?
- [ ] 이슈는 등록했나요?
- [ ] 라벨은 등록했나요?

## #️⃣ 연관된 이슈

> ex) #138 

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 프로필 편집을 위한 새 편집 훅과 파라미터 타입이 추가되었습니다.
  * 프로필 편집 흐름이 컴포넌트 분리 및 콜백 기반으로 개선되었습니다.

* **개선사항**
  * 즐겨찾기 태그 편집 UI가 부모-제어형으로 변경되어 태그 변경 콜백을 제공합니다.
  * 완료 버튼에 대기/비활성화 상태가 반영됩니다.
  * 대시보드 색상 팔레트, 차트 호버 동작 및 레이아웃 패딩이 조정되었습니다.
  * 포스터 배경 위치/스타일이 고정 레이아웃으로 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->