### PR TITLE
[OT-326][FIX]: 북마크 숏폼 클릭 이벤트 추가

### DIFF
--- a/src/features/bookmark/components/BookmarkShortsList.tsx
+++ b/src/features/bookmark/components/BookmarkShortsList.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
-import { Play, X, Loader2 } from "lucide-react";
+import { Loader2, Play, X } from "lucide-react";
 import { ConfirmModal } from "@base-components";
 import { useBookmarkShortForms } from "@entities/bookmark/hooks";
 import { useToggleBookmark } from "@entities/bookmark/hooks";
@@ -12,8 +13,16 @@ export default function BookmarkShortsList() {
   const [isDeleteShortsModalOpen, setIsDeleteShortsModalOpen] =
     useState<boolean>(false);
   const [selectedMediaId, setSelectedMediaId] = useState<number | null>(null);
+  const router = useRouter();
 
-  const { bookmarkShortForms, isLoading, isError, hasNextPage, isFetchingNextPage, fetchNextPage } = useBookmarkShortForms();
+  const {
+    bookmarkShortForms,
+    isLoading,
+    isError,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useBookmarkShortForms();
   const { mutate: deleteBookmark, isPending } = useToggleBookmark();
 
   const { observerRef } = useInfiniteScroll({
@@ -61,6 +70,7 @@ export default function BookmarkShortsList() {
         {bookmarkShortForms.map((item) => (
           <div
             key={item.mediaId}
+            onClick={() => router.push(`/shorts/${item.mediaId}`)}
             className="group hover:bg-ot-gray-900 relative flex w-full cursor-pointer items-center gap-8 rounded-xl p-4 transition-all duration-200"
           >
             {/* 숏폼 이미지 (9:16) */}
@@ -118,7 +128,10 @@ export default function BookmarkShortsList() {
       {/* 무한스크롤 감지 영역 */}
       <div ref={observerRef} className="flex h-4 justify-center">
         {isFetchingNextPage && (
-          <Loader2 className="text-ot-placeholder mt-4 animate-spin" size={20} />
+          <Loader2
+            className="text-ot-placeholder mt-4 animate-spin"
+            size={20}
+          />
         )}
       </div>
 


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 적어주세요

- [x] 북마크에서 숏폼 클릭 시, 해당 숏폼 피드 페이지로 이동
http://localhost:3000/mypage?tab=bookmark&filter=shorts에서 요소 클릭 시,
http://localhost:3000/shorts/{mediaId}로 이동


### 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. src에 이미지 url만 등록하면 됩니다. -->

| 구현 내용 |             SE              |
| :-------: | :-------------------------: |
|    GIF    | <img src = "" width ="250"> |



https://github.com/user-attachments/assets/68cac8da-34d3-43f4-97bb-eca74a8b3464



## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

`HomeView`

- BookmarkShortsList.tsx 클릭 이벤트 부분

```
{bookmarkShortForms.map((item) => (
  <div
    key={item.mediaId}
    onClick={() => router.push(`/shorts/${item.mediaId}`)}
    className="group hover:bg-ot-gray-900 relative flex w-full cursor-pointer items-center gap-8 rounded-xl p-4 transition-all      duration-200"
          >
```

## ☑️ 체크 리스트

> 체크 리스트를 확인해주세요

- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?

## #️⃣ 연관된 이슈

> ex) #141 

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요
