### PR TITLE
[OT-371] [FIX]: CarouselView 디테일 수정

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,7 +15,7 @@ export default function Home() {
     <div>
       <Header />
       <Suspense fallback={<HomeSkeleton />}>
-        <MainCarousel title="" itemHeight={400} itemWidth={1350} />
+        <MainCarousel title="" itemHeight={400} />
         <CustomRecommendCarousel />
         <TrendingCarousel />
         <RecommendCarousel />

--- a/src/entities/home/components/AiCardSlide.tsx
+++ b/src/entities/home/components/AiCardSlide.tsx
@@ -72,7 +72,7 @@ export default function AiCardSlide({ aiCard, onClose }: AiCardSlideProps) {
 
   return (
     <div
-      className={`relative flex h-full w-full flex-col bg-linear-to-r ${gradient} overflow-y-auto rounded-xl px-8 py-6`}
+      className={`no-scrollbar relative flex h-full w-full flex-col overflow-y-auto bg-linear-to-r ${gradient} rounded-xl px-8 py-6`}
     >
       {/* 닫기 버튼 */}
       <button
@@ -88,11 +88,11 @@ export default function AiCardSlide({ aiCard, onClose }: AiCardSlideProps) {
       <p className="text-ot-text text-2xl font-bold">현재 나의 감정 상태는?</p>
 
       {/* 중단: 카드(좌) + 구분선 + 말풍선+포스터(우) */}
-      <div className="flex flex-1 items-center justify-center gap-20">
+      <div className="flex flex-1 justify-center gap-20">
         {/* 왼쪽) 감정 카드 이미지 */}
         <div
           onClick={handleCardClick}
-          className="flex shrink-0 cursor-pointer flex-col items-center justify-center"
+          className="flex shrink-0 cursor-pointer flex-col items-center justify-center self-center"
           style={{ perspective: "1000px" }}
         >
           <motion.div
@@ -138,7 +138,7 @@ export default function AiCardSlide({ aiCard, onClose }: AiCardSlideProps) {
         </div>
 
         {/* 세로 구분선 */}
-        <div className="h-60 w-px shrink-0 bg-white/20" />
+        <div className="h-60 w-px shrink-0 self-center bg-white/20" />
 
         {/* 오른쪽) 말풍선 + 포스터 3개 */}
         <div className="flex flex-col items-center gap-4">

--- a/src/entities/home/components/MainCarousel.tsx
+++ b/src/entities/home/components/MainCarousel.tsx
@@ -17,13 +17,11 @@ const BANNER_IMAGES = [
 
 interface ContentCarouselProps {
   title: string;
-  itemWidth?: number;
   itemHeight?: number;
 }
 
 export default function MainCarousel({
   title,
-  itemWidth = 160,
   itemHeight = 220,
 }: ContentCarouselProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -43,6 +41,7 @@ export default function MainCarousel({
     return () => observer.disconnect();
   }, []);
 
+  const itemWidth = containerWidth > 0 ? containerWidth - 2 * PEEK : 0;
   const itemCount = (aiCardData && !dismissed ? 1 : 0) + BANNER_IMAGES.length;
   const itemsPerPage = Math.max(
     1,


### PR DESCRIPTION
## 📝 작업 내용

> 메인 캐러셀 뷰와 AiCard 디테일적으로 수정했습니다


### 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. src에 이미지 url만 등록하면 됩니다. -->

| 구현 내용 |             AiCard             | 
| :-------: | :-------------------------: |
|    GIF    | <img src = "https://github.com/user-attachments/assets/e0e1e441-76f3-488c-b264-91221032651d" width ="950"> | 

- 반응형

https://github.com/user-attachments/assets/d114edc9-eee1-4a43-ab60-bcef1791f4c1


## 🖥️ 주요 코드 설명

`MainCarousel.tsx`

- `itemWidth`prop 제거 → 내부에서 `containerWidth - 2 * PEEK`로 계산
- 이미 ResizeObserver가 `containerWidth`를 추적하고 있어서, 화면 너비가 바뀔 때마다 캐러셀 아이템 크기가 자동으로 계산
- page.tsx에서 하드코딩된 `itemWidth={1350}` 제거

`AiCardSlide.tsx`
- `overflow-y-auto + no-scrollbar` → 내용이 넘칠 때 스크롤은 되지만 스크롤바는 숨김

```ts
  const itemWidth = containerWidth > 0 ? containerWidth - 2 * PEEK : 0;
```

## ☑️ 체크 리스트

> 체크 리스트를 확인해주세요

- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?

## #️⃣ 연관된 이슈

> ex) #156 

## 💬 리뷰 요구사항

> 없습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 캐러셀이 장치 화면 크기에 따라 자동으로 너비를 조정하여 더욱 반응성 있는 경험을 제공합니다.
  * AI 카드 슬라이드의 수직 정렬과 스크롤 동작이 개선되어 더 나은 시각적 배치를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->