### PR TITLE
[OT-372] [FIX]: 캐러셀 반응형 수정

### DIFF
--- a/src/entities/home/components/MainCarousel.tsx
+++ b/src/entities/home/components/MainCarousel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { AiCardSlide } from "@entities/home/components";
 import { useMoodCard } from "@entities/home/hooks";
 import { ScrollEdgeButton } from "@shared/components";
@@ -24,40 +24,20 @@ export default function MainCarousel({
   title,
   itemHeight = 220,
 }: ContentCarouselProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [containerWidth, setContainerWidth] = useState(0);
   const [currentPage, setCurrentPage] = useState(0);
   const { data: aiCardData } = useMoodCard();
   const [dismissed, setDismissed] = useState(false);
 
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    const observer = new ResizeObserver(([entry]) => {
-      setContainerWidth(entry.contentRect.width);
-      setCurrentPage(0);
-    });
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, []);
-
-  const itemWidth = containerWidth > 0 ? containerWidth - 2 * PEEK : 0;
   const itemCount = (aiCardData && !dismissed ? 1 : 0) + BANNER_IMAGES.length;
-  const itemsPerPage = Math.max(
-    1,
-    Math.floor((containerWidth - 2 * PEEK + GAP) / (itemWidth + GAP)),
-  );
-  const pageWidth = itemsPerPage * (itemWidth + GAP);
-  const totalPages = Math.ceil(itemCount / itemsPerPage);
+  const totalPages = itemCount;
   const isFirst = currentPage === 0;
   const isLast = currentPage >= totalPages - 1;
-  const translateX = isFirst ? 0 : currentPage * pageWidth - PEEK;
 
   return (
     <div className="bg-ot-background w-full pt-[1.33rem] pr-12 pb-[1.33rem] pl-12">
       <h2 className="text-ot-text mb-5 text-2xl font-bold">{title}</h2>
 
-      <div className="relative" ref={containerRef}>
+      <div className="relative">
         {!isFirst && (
           <ScrollEdgeButton
             direction="left"
@@ -71,13 +51,19 @@ export default function MainCarousel({
             className="flex transition-transform duration-300 ease-in-out"
             style={{
               gap: `${GAP}px`,
-              transform: `translateX(-${translateX}px)`,
+              transform: `translateX(calc(
+                -${currentPage} * (100% - ${PEEK * 2}px + ${GAP}px)
+                + ${currentPage > 0 ? PEEK : 0}px
+              ))`,
             }}
           >
             {aiCardData && !dismissed && (
               <div
                 className="bg-ot-gray-800 relative shrink-0 overflow-hidden rounded-xl"
-                style={{ width: `${itemWidth}px`, height: `${itemHeight}px` }}
+                style={{
+                  width: `calc(100% - ${PEEK * 2}px)`,
+                  height: `${itemHeight}px`,
+                }}
               >
                 <AiCardSlide
                   aiCard={aiCardData}
@@ -93,7 +79,10 @@ export default function MainCarousel({
               <div
                 key={idx}
                 className="bg-ot-gray-800 relative shrink-0 overflow-hidden rounded-xl"
-                style={{ width: `${itemWidth}px`, height: `${itemHeight}px` }}
+                style={{
+                  width: `calc(100% - ${PEEK * 2}px)`,
+                  height: `${itemHeight}px`,
+                }}
               >
                 <Image
                   src={banner.src}


### PR DESCRIPTION
## 📝 작업 내용

> 캐러셀 반응형 수정

### 📷 스크린샷

https://github.com/user-attachments/assets/1ccb1bac-2a1e-4828-b806-48a2aac5fd6e



## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

`MainCarousel`

- currentPage * (아이템너비 + GAP) → 현재 페이지만큼 왼쪽으로 이동
-  `+ PEEK` → 첫 페이지가 아닐 때 이전 카드 끝이 살짝 보이도록 당겨주기
- 첫 페이지(currentPage === 0)는 PEEK 보정 없이 그냥 0

```ts
...
width: `calc(100% - ${PEEK * 2}px)`
// 부모 너비에서 양쪽 PEEK(48px)를 뺀 값
// 100% - 96px
...
transform: `translateX(calc(
  -${currentPage} * (100% - ${PEEK * 2}px + ${GAP}px)
  + ${currentPage > 0 ? PEEK : 0}px
))`
...
```

## ☑️ 체크 리스트

> 체크 리스트를 확인해주세요

- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?

## #️⃣ 연관된 이슈

> ex) #158 

## 💬 리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 리팩토링

* **캐러셀 반응형 디자인 개선**
  * 캐러셀의 크기 측정 및 계산 방식이 개선되었습니다. 이제 모든 화면 크기에서 더 안정적이고 부드러운 슬라이드 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->