### PR TITLE
[OT-372] [FIX]: 다음 재생 banner 에러 해결

### DIFF
--- a/src/features/player/components/AutoPlayNextBanner.tsx
+++ b/src/features/player/components/AutoPlayNextBanner.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { useEffect, useRef, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import { Play, X } from "lucide-react";
 
 interface NextMediaInfo {
@@ -19,82 +19,110 @@ interface AutoPlayNextBannerProps {
   showControls: boolean;
 }
 
-export const AutoPlayNextBanner = ({
-  type,
-  nextMedia,
-  countdownSec,
-  onConfirm,
-  onCancel,
-  showControls,
-}: AutoPlayNextBannerProps) => {
-  const defaultSec = countdownSec ?? (type === "contents" ? 15 : 5);
-  const [remaining, setRemaining] = useState(defaultSec);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+export const AutoPlayNextBanner = memo(
+  ({
+    type,
+    nextMedia,
+    countdownSec,
+    onConfirm,
+    onCancel,
+    showControls,
+  }: AutoPlayNextBannerProps) => {
+    const defaultSec = countdownSec ?? (type === "contents" ? 15 : 5);
+    const [remaining, setRemaining] = useState(defaultSec);
+    const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const onConfirmRef = useRef(onConfirm);
 
-  useEffect(() => {
-    intervalRef.current = setInterval(() => {
-      setRemaining((prev) => {
-        if (prev <= 1) {
-          clearInterval(intervalRef.current!);
-          onConfirm();
-          return 0;
-        }
-        return prev - 1;
-      });
-    }, 1000);
+    useEffect(() => {
+      onConfirmRef.current = onConfirm;
+    }, [onConfirm]);
 
-    return () => {
+    useEffect(() => {
+      intervalRef.current = setInterval(() => {
+        setRemaining((prev) => {
+          if (prev <= 1) {
+            clearInterval(intervalRef.current!);
+            return 0;
+          }
+          return prev - 1;
+        });
+      }, 1000);
+
+      return () => {
+        if (intervalRef.current) clearInterval(intervalRef.current);
+      };
+    }, []);
+
+    useEffect(() => {
+      if (remaining === 0) {
+        onConfirmRef.current();
+      }
+    }, [remaining]);
+
+    const handleConfirm = () => {
       if (intervalRef.current) clearInterval(intervalRef.current);
+      onConfirmRef.current();
     };
-  }, [onConfirm]);
 
-  const bottomClass = showControls ? "bottom-20" : "bottom-4";
+    const handleCancel = () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+      onCancel();
+    };
 
-  // 콘텐츠
-  if (type === "contents") {
-    return (
-      <div
-        className={`bg-ot-gray-900/90 hover:bg-ot-gray-800/90 absolute right-4 ${bottomClass} flex items-center gap-4 rounded-md px-3 py-3 shadow-lg backdrop-blur-sm transition-all`}
-      >
+    const bottomClass = showControls ? "bottom-20" : "bottom-4";
+
+    // 콘텐츠
+    if (type === "contents") {
+      return (
         <div
-          className="relative h-14 w-22 shrink-0 cursor-pointer overflow-hidden rounded-md"
-          onClick={onConfirm}
+          className={`bg-ot-gray-900/90 hover:bg-ot-gray-800/90 absolute right-4 ${bottomClass} flex items-center gap-4 rounded-md px-3 py-3 shadow-lg backdrop-blur-sm transition-all`}
         >
-          <Image
-            src={nextMedia.thumbnailUrl}
-            alt={nextMedia.title}
-            fill
-            className="object-cover"
-          />
-        </div>
+          <div
+            className="relative h-14 w-22 shrink-0 cursor-pointer overflow-hidden rounded-md"
+            onClick={handleConfirm}
+          >
+            <Image
+              src={nextMedia.thumbnailUrl}
+              alt={nextMedia.title}
+              fill
+              className="object-cover"
+            />
+          </div>
 
-        <div className="flex cursor-pointer flex-col gap-1" onClick={onConfirm}>
-          <p className="text-ot-text line-clamp-1 max-w-35 text-sm leading-tight font-semibold">
-            {nextMedia.title}
-          </p>
-          <p className="text-ot-gray-400 text-xs">{remaining}초 뒤 연속 재생</p>
-        </div>
+          <div
+            className="flex cursor-pointer flex-col gap-1"
+            onClick={handleConfirm}
+          >
+            <p className="text-ot-text line-clamp-1 max-w-35 text-sm leading-tight font-semibold">
+              {nextMedia.title}
+            </p>
+            <p className="text-ot-gray-400 text-xs">
+              {remaining}초 뒤 연속 재생
+            </p>
+          </div>
 
-        <button
-          onClick={onCancel}
-          className="text-ot-gray-600 hover:text-ot-text ml-1 shrink-0 self-start p-1 transition-colors"
-          aria-label="자동재생 취소"
-        >
-          <X size={16} />
-        </button>
-      </div>
+          <button
+            onClick={handleCancel}
+            className="text-ot-gray-600 hover:text-ot-text ml-1 shrink-0 self-start p-1 transition-colors"
+            aria-label="자동재생 취소"
+          >
+            <X size={16} />
+          </button>
+        </div>
+      );
+    }
+
+    // 에피소드
+    return (
+      <button
+        onClick={handleConfirm}
+        className={`bg-ot-gray-900/90 hover:bg-ot-gray-800/90 absolute right-4 ${bottomClass} flex items-center gap-3 rounded-md px-4 py-3 shadow-lg backdrop-blur-sm transition-all`}
+      >
+        <Play size={16} fill="currentColor" />
+        <span className="text-ot-text text-sm font-semibold whitespace-nowrap">
+          {remaining}초 후 다음 화 재생
+        </span>
+      </button>
     );
-  }
-  // 에피소드
-  return (
-    <button
-      onClick={onConfirm}
-      className={`bg-ot-gray-900/90 hover:bg-ot-gray-800/90 absolute right-4 ${bottomClass} flex items-center gap-3 rounded-md px-4 py-3 shadow-lg backdrop-blur-sm transition-all`}
-    >
-      <Play size={16} fill="currentColor" />
-      <span className="text-ot-text text-sm font-semibold whitespace-nowrap">
-        {remaining}초 후 다음 화 재생
-      </span>
-    </button>
-  );
-};
+  },
+);

--- a/src/features/player/components/VideoPlayer.tsx
+++ b/src/features/player/components/VideoPlayer.tsx
@@ -94,10 +94,13 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
       if (duration <= 0) return;
 
       const ratio = currentTime / duration;
-
       if (ratio < AUTO_PLAY_THRESHOLD) {
         isCancelledRef.current = false;
-        showNextBannerRef.current = false;
+        if (showNextBannerRef.current) {
+          showNextBannerRef.current = false;
+          setShowNextBanner(false);
+        }
+        return;
       }
 
       if (

--- a/src/features/player/components/VideoPlayer.tsx
+++ b/src/features/player/components/VideoPlayer.tsx
@@ -66,7 +66,7 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
 
   const [showNextBanner, setShowNextBanner] = useState<boolean>(false);
   const showNextBannerRef = useRef(false);
-
+  const isCancelledRef = useRef(false);
   const {
     enterPip,
     exitPip,
@@ -91,10 +91,19 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
       currentTimeRef.current = videoRef.current.currentTime;
 
       const { currentTime, duration } = videoRef.current;
+      if (duration <= 0) return;
+
+      const ratio = currentTime / duration;
+
+      if (ratio < AUTO_PLAY_THRESHOLD) {
+        isCancelledRef.current = false;
+        showNextBannerRef.current = false;
+      }
+
       if (
-        duration > 0 &&
-        currentTime / duration >= AUTO_PLAY_THRESHOLD &&
-        !showNextBannerRef.current
+        ratio >= AUTO_PLAY_THRESHOLD &&
+        !showNextBannerRef.current &&
+        !isCancelledRef.current
       ) {
         showNextBannerRef.current = true;
         setShowNextBanner(true);
@@ -352,7 +361,7 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
   const handleNextConfirm = useCallback(async () => {
     if (!nextMedia) return;
     showNextBannerRef.current = false;
-    setShowNextBanner(false);
+    // setShowNextBanner(false);
     isSavedRef.current = true;
 
     if (nextMedia.mediaType === "SERIES") {
@@ -425,6 +434,7 @@ export const VideoPlayer = ({ mediaId }: VideoPlayerProps) => {
           nextMedia={nextMedia}
           onConfirm={handleNextConfirm}
           onCancel={() => {
+            isCancelledRef.current = true;
             showNextBannerRef.current = false;
             setShowNextBanner(false);
           }}


### PR DESCRIPTION
## 📝 작업 내용

> - 콘텐츠일 때, 다음 재생 배너의 cancel이 안되던 문제를 해결했습니다.
> - 'X' 버튼을 누른 뒤 다시 이전으로 갔다가 95% 이상 재생으로 넘어가면 다시 배너가 나오게끔 수정했습니다.
> - 시리즈일 때, 5초 뒤 자동재생 배너를 누르면 다시 5초 뒤 배너가 렌더링되는 에러를 해결했습니다.

### 📷 스크린샷


## 🖥️ 주요 코드 설명


## ☑️ 체크 리스트

> 체크 리스트를 확인해주세요

- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?

## #️⃣ 연관된 이슈

> ex) # 이슈번호

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 자동재생 다음 동영상 배너의 표시 타이밍과 취소 동작을 개선하여 오작동 감소
  * 배너 취소 시 선택이 올바르게 반영되도록 수정
  * 재생 상태 감지 및 배너 트리거 로직 안정성 향상, 불필요한 재노출 방지
<!-- end of auto-generated comment: release notes by coderabbit.ai -->